### PR TITLE
add the rest of the unadded ncurses functions

### DIFF
--- a/ncurses.nim
+++ b/ncurses.nim
@@ -57,7 +57,7 @@ type
     yoffset: cshort          # real begy is _begy + _yoffset
     bkgrnd: cchar_t          # current background char/attribute pair
     color: cint              # current color-pair for non-space character
-  window* {.deprecated: "Use Pwindow instead.".} = Window
+  window* {.deprecated: "Use PWindow instead".} = Window
 
   pdat = object ## pad data
     pad_y*,      pad_x*:     cshort
@@ -603,10 +603,10 @@ proc getcchar*(wcval: ptr cchar_t, wch: WideCString, attrs: ptr attr_t, color_pa
 proc setcchar*(wcval: ptr cchar_t, wch: WideCString, attrs: attr_t, color_pair: cshort, opts: pointer): ErrCode {.cdecl, importc, discardable, dynlib: libncurses.}
 
 #getch: get (or push back) characters from the terminal keyboard
-proc getch*(): cchar {.cdecl, importc, discardable, dynlib: libncurses.}
+proc getch*(): cint {.cdecl, importc, discardable, dynlib: libncurses.}
   ## Read a character from the stdscr window.
   ## @Returns: ERR on failure and OK upon successful completion.
-proc wgetch*(win: PWindow): cchar {.cdecl, importc, discardable, dynlib: libncurses.}
+proc wgetch*(win: PWindow): cint {.cdecl, importc, discardable, dynlib: libncurses.}
   ## Read a character from the specified window.
   ## @Param: 'sourceWindow' the window to read a character from.
   ## @Returns: ERR on failure and OK upon successful completion.

--- a/ncurses.nim
+++ b/ncurses.nim
@@ -5,7 +5,6 @@ elif defined(macosx):
   const libncurses* = "libncurses.dylib"
 else:
   const libncurses* = "libncursesw.so"
-{.pragma: ncurses_default, discardable, cdecl, dynlib: libncurses.}
 
 type
   # 32 or 64
@@ -19,8 +18,8 @@ type
     ext_color: cint
 
   ldat = object ## line data
-  Screen* {.ncurses_default, importc: "struct SCREEN".} = object
-  Terminal {.ncurses_default, importc: "struct TERMINAL".} = object
+  Screen* {.importc.} = object
+  Terminal {.importc.} = object
   Window* = win_st
   win_st = object ## window struct
     cury*, curx*: cshort      # current cursor position
@@ -107,128 +106,128 @@ template PAIR_NUMBER*(a: untyped): untyped =
   (NCURSES_CAST(int, ((NCURSES_CAST(uint64, (a)) and A_COLOR) shr
     NCURSES_ATTR_SHIFT)))
 
-proc start_color*(): ErrCode {.ncurses_default, importc: "start_color".}
+proc start_color*(): ErrCode {.cdecl, importc, discardable, dynlib: libncurses.}
   ## Initialises the the eight basic colours and the two global varables COLORS and COLOR_PAIRS.
   ## It also restores the colours on the terminal to the values that they had when the
   ## terminal was just turned on.
   ## @Note: It is good practice to call this routine right after initscr. It must be
   ## called before any other colour manipulating routines.
-proc has_colors*(): bool {.ncurses_default, importc: "has_colors".}
+proc has_colors*(): bool {.cdecl, importc, discardable, dynlib: libncurses.}
   ## Used to determine if the terminal can manipulate colours.
   ## @Returns: true if the terminal can manipulate colours or false if it cannot.
-proc can_change_color*(): bool {.ncurses_default, importc: "can_change_color".}
+proc can_change_color*(): bool {.cdecl, importc, discardable, dynlib: libncurses.}
   ## Used to determine if the terminal supports colours and can change their definitions.
   ## @Returns: true if the terminal supports colours and can change their definitions or
   ## false otherwise.
-proc init_pair*(pair, f,b: cshort): ErrCode {.ncurses_default, importc: "init_pair".}
+proc init_pair*(pair, f,b: cshort): ErrCode {.cdecl, importc, discardable, dynlib: libncurses.}
   ## Changes the definition of a colour pair.
   ## @Param: 'pair' the number of the colour pair to change.
   ## @Param: 'foreground': the foreground colour number.
   ## @Param: 'background': the background colour number.
   ## @Returns: ERR on failure and OK upon successful completion.
-proc init_color*(color: cshort, r, g, b: cshort): ErrCode {.ncurses_default, importc: "init_color".}
-proc init_extended_pair*(pair, f,b: cint): ErrCode {.ncurses_default, importc: "init_extended_pair".}
-proc init_extended_color*(color: cint, r, g, b: cint): ErrCode {.ncurses_default, importc: "init_extended_color".}
-proc color_content*(color: cshort, r, g, b: ptr cshort): ErrCode {.ncurses_default, importc: "color_content".}
-proc pair_content*(pair: cshort, f,b: ptr cshort): ErrCode {.ncurses_default, importc: "pair_content".}
-proc extended_color_content*(color: cint, r, g, b: ptr cint): ErrCode {.ncurses_default, importc: "extended_color_content".}
-proc pair_content*(pair: cint, f,b: ptr cint): ErrCode {.ncurses_default, importc: "extended_pair_content".}
-proc reset_color_pairs*(): void {.ncurses_default, importc: "reset_color_pairs".}
+proc init_color*(color: cshort, r, g, b: cshort): ErrCode {.cdecl, importc, discardable, dynlib: libncurses.}
+proc init_extended_pair*(pair, f,b: cint): ErrCode {.cdecl, importc, discardable, dynlib: libncurses.}
+proc init_extended_color*(color: cint, r, g, b: cint): ErrCode {.cdecl, importc, discardable, dynlib: libncurses.}
+proc color_content*(color: cshort, r, g, b: ptr cshort): ErrCode {.cdecl, importc, discardable, dynlib: libncurses.}
+proc pair_content*(pair: cshort, f,b: ptr cshort): ErrCode {.cdecl, importc, discardable, dynlib: libncurses.}
+proc extended_color_content*(color: cint, r, g, b: ptr cint): ErrCode {.cdecl, importc, discardable, dynlib: libncurses.}
+proc pair_content*(pair: cint, f,b: ptr cint): ErrCode {.cdecl, importc, discardable, dynlib: libncurses.}
+proc reset_color_pairs*(): void {.cdecl, importc, discardable, dynlib: libncurses.}
 
 #threads: thread support
-proc get_escdelay*(): cint {.ncurses_default, importc: "get_escdelay".}
-proc set_escdelay*(size: cint): ErrCode {.ncurses_default, importc: "set_escdelay".}
-proc set_tabsize*(size: cint): ErrCode {.ncurses_default, importc: "use_tabsize".}
-proc use_screen*(scr: PScreen, screen_cb: proc(scr: PScreen, pt: pointer): cint): ErrCode {.ncurses_default, importc: "use_screen".}
-proc use_window*(win: PWindow, screen_cb: proc(win: PWindow, pt: pointer): cint): ErrCode {.ncurses_default, importc: "use_window".}
+proc get_escdelay*(): cint {.cdecl, importc, discardable, dynlib: libncurses.}
+proc set_escdelay*(size: cint): ErrCode {.cdecl, importc, discardable, dynlib: libncurses.}
+proc set_tabsize*(size: cint): ErrCode {.cdecl, importc, discardable, dynlib: libncurses.}
+proc use_screen*(scr: PScreen, screen_cb: proc(scr: PScreen, pt: pointer): cint): ErrCode {.cdecl, importc, discardable, dynlib: libncurses.}
+proc use_window*(win: PWindow, screen_cb: proc(win: PWindow, pt: pointer): cint): ErrCode {.cdecl, importc, discardable, dynlib: libncurses.}
 
 #add_wchs: Adding complex characters to a window
-proc add_wch*(wch: ptr cchar_t): ErrCode {.ncurses_default, importc: "add_wch".}
-proc wadd_wch*(win: PWindow, wch: ptr cchar_t): ErrCode {.ncurses_default, importc: "wadd_wch".}
-proc mvadd_wch*(y, x: cint, wch: ptr cchar_t): ErrCode {.ncurses_default, importc: "mvadd_wch".}
-proc mvwadd_wch*(win: PWindow, y, x: cint, wch: ptr cchar_t): ErrCode {.ncurses_default, importc: "mvwadd_wch".}
-proc echo_wchar*(wch: ptr cchar_t): ErrCode {.ncurses_default, importc: "echo_wchar".}
-proc wech_wchar*(win: PWindow, wch: ptr cchar_t): ErrCode {.ncurses_default, importc: "wech_wchar".}
+proc add_wch*(wch: ptr cchar_t): ErrCode {.cdecl, importc, discardable, dynlib: libncurses.}
+proc wadd_wch*(win: PWindow, wch: ptr cchar_t): ErrCode {.cdecl, importc, discardable, dynlib: libncurses.}
+proc mvadd_wch*(y, x: cint, wch: ptr cchar_t): ErrCode {.cdecl, importc, discardable, dynlib: libncurses.}
+proc mvwadd_wch*(win: PWindow, y, x: cint, wch: ptr cchar_t): ErrCode {.cdecl, importc, discardable, dynlib: libncurses.}
+proc echo_wchar*(wch: ptr cchar_t): ErrCode {.cdecl, importc, discardable, dynlib: libncurses.}
+proc wech_wchar*(win: PWindow, wch: ptr cchar_t): ErrCode {.cdecl, importc, discardable, dynlib: libncurses.}
 
 #add_wchstr: Adding an array of complex characters to a window
-proc add_wchstr*(wchstr: ptr cchar_t): ErrCode {.ncurses_default, importc: "add_wchstr".}
-proc add_wchnstr*(wchstr: ptr cchar_t, numberOfCharacters: cint): ErrCode {.ncurses_default, importc: "add_wchnstr".}
-proc wadd_wchstr*(win: PWindow, wchstr: ptr cchar_t): ErrCode {.ncurses_default, importc: "wadd_wchstr".}
-proc wadd_wchnstr*(win: PWindow, wchstr: ptr cchar_t, n: cint): ErrCode {.ncurses_default, importc: "wadd_wchnstr".}
-proc mvadd_wchstr*(y, x: cint, wchstr: ptr cchar_t): ErrCode {.ncurses_default, importc: "mvadd_wchstr".}
-proc mvadd_wchnstr*(y, x: cint, wchstr: ptr cchar_t, n: cint): ErrCode {.ncurses_default, importc: "mvadd_wchnstr".}
-proc mvwadd_wchstr*(win: PWindow, y, x: cint, wchstr: ptr cchar_t): ErrCode {.ncurses_default, importc: "mvwadd_wchstr".}
-proc mvwadd_wchnstr*(win: PWindow, y, x: cint, wchstr: ptr cchar_t, n: cint): ErrCode {.ncurses_default, importc: "mvwadd_wchnstr".}
+proc add_wchstr*(wchstr: ptr cchar_t): ErrCode {.cdecl, importc, discardable, dynlib: libncurses.}
+proc add_wchnstr*(wchstr: ptr cchar_t, numberOfCharacters: cint): ErrCode {.cdecl, importc, discardable, dynlib: libncurses.}
+proc wadd_wchstr*(win: PWindow, wchstr: ptr cchar_t): ErrCode {.cdecl, importc, discardable, dynlib: libncurses.}
+proc wadd_wchnstr*(win: PWindow, wchstr: ptr cchar_t, n: cint): ErrCode {.cdecl, importc, discardable, dynlib: libncurses.}
+proc mvadd_wchstr*(y, x: cint, wchstr: ptr cchar_t): ErrCode {.cdecl, importc, discardable, dynlib: libncurses.}
+proc mvadd_wchnstr*(y, x: cint, wchstr: ptr cchar_t, n: cint): ErrCode {.cdecl, importc, discardable, dynlib: libncurses.}
+proc mvwadd_wchstr*(win: PWindow, y, x: cint, wchstr: ptr cchar_t): ErrCode {.cdecl, importc, discardable, dynlib: libncurses.}
+proc mvwadd_wchnstr*(win: PWindow, y, x: cint, wchstr: ptr cchar_t, n: cint): ErrCode {.cdecl, importc, discardable, dynlib: libncurses.}
 
 #addch: Adding a character (with attributes) to a window
-proc addch*(character: chtype): ErrCode {.ncurses_default, importc: "addch".}
+proc addch*(character: chtype): ErrCode {.cdecl, importc, discardable, dynlib: libncurses.}
   ## Puts a character into the stdscr at its current window position and then advances
   ## the current window position to the next position.
   ## @Param: 'character' the character to put into the current window.
   ## @Returns: ERR on failure and OK upon successful completion.
-proc waddch*(win: PWindow, ch: chtype): ErrCode {.ncurses_default, importc: "waddch".}
-proc mvaddch*(y: int; x: int; character: chtype): cint {.ncurses_default, importc: "mvaddch".}
+proc waddch*(win: PWindow, ch: chtype): ErrCode {.cdecl, importc, discardable, dynlib: libncurses.}
+proc mvaddch*(y: int; x: int; character: chtype): cint {.cdecl, importc, discardable, dynlib: libncurses.}
   ## Moves the cursor to the specified position and outputs the provided character.
   ## The cursor is then advanced to the next position.
   ## @Param: 'y' the line to move the cursor to.
   ## @Param: 'x' the column to move the cursor to.
   ## @Param: 'character' the character to put into the current window.
   ## @Returns: ERR on failure and OK upon successful completion.
-proc mvwaddch*(win: PWindow, y, x: int, ch: chtype): ErrCode {.ncurses_default, importc: "mvwaddch".}
-proc echochar*(ch: chtype): ErrCode {.ncurses_default, importc: "echochar".}
-proc wechochar*(win: PWindow, ch: chtype): ErrCode {.ncurses_default, importc: "wechochar".}
+proc mvwaddch*(win: PWindow, y, x: int, ch: chtype): ErrCode {.cdecl, importc, discardable, dynlib: libncurses.}
+proc echochar*(ch: chtype): ErrCode {.cdecl, importc, discardable, dynlib: libncurses.}
+proc wechochar*(win: PWindow, ch: chtype): ErrCode {.cdecl, importc, discardable, dynlib: libncurses.}
 
 #addchstr: Adding a string of characters (and attributes) to a window
-proc addchstr*(chstr: ptr chtype): ErrCode {.ncurses_default, importc: "addchstr".}
-proc addchnstr*(chstr: ptr chtype, n: cint): ErrCode {.ncurses_default, importc: "addchnstr".}
-proc waddchstr*(win: PWindow, chstr: ptr chtype): ErrCode {.ncurses_default, importc: "waddchstr".}
-proc waddchnstr*(win: PWindow, chstr: ptr chtype, n: cint): ErrCode {.ncurses_default, importc: "waddchnstr".}
-proc mvaddchstr*(y, x: cint, chstr: ptr chtype): ErrCode {.ncurses_default, importc: "mvaddchstr".}
-proc mvaddchnstr*(y, x: cint, chstr: ptr chtype, n: cint): ErrCode {.ncurses_default, importc: "mvaddchnstr".}
-proc mvwaddchstr*(win: PWindow, y, x: cint, chstr: ptr chtype): ErrCode {.ncurses_default, importc: "mvwaddchstr".}
-proc mvwaddchnstr*(win: PWindow, y, x: cint, chstr: ptr chtype, n: cint): ErrCode {.ncurses_default, importc: "mvwaddchnstr".}
+proc addchstr*(chstr: ptr chtype): ErrCode {.cdecl, importc, discardable, dynlib: libncurses.}
+proc addchnstr*(chstr: ptr chtype, n: cint): ErrCode {.cdecl, importc, discardable, dynlib: libncurses.}
+proc waddchstr*(win: PWindow, chstr: ptr chtype): ErrCode {.cdecl, importc, discardable, dynlib: libncurses.}
+proc waddchnstr*(win: PWindow, chstr: ptr chtype, n: cint): ErrCode {.cdecl, importc, discardable, dynlib: libncurses.}
+proc mvaddchstr*(y, x: cint, chstr: ptr chtype): ErrCode {.cdecl, importc, discardable, dynlib: libncurses.}
+proc mvaddchnstr*(y, x: cint, chstr: ptr chtype, n: cint): ErrCode {.cdecl, importc, discardable, dynlib: libncurses.}
+proc mvwaddchstr*(win: PWindow, y, x: cint, chstr: ptr chtype): ErrCode {.cdecl, importc, discardable, dynlib: libncurses.}
+proc mvwaddchnstr*(win: PWindow, y, x: cint, chstr: ptr chtype, n: cint): ErrCode {.cdecl, importc, discardable, dynlib: libncurses.}
 
 #addstr: Adding a string of characters to a window (cstring)
-proc addstr*(str: cstring): ErrCode {.ncurses_default, importc: "addstr".}
+proc addstr*(str: cstring): ErrCode {.cdecl, importc, discardable, dynlib: libncurses.}
   ## Adds a string of characters the the stdscr and advances the cursor.
   ## @Param: The string to add the stdscr.
   ## @Returns: ERR on failure and OK upon successful completion.
-proc addnstr*(str: cstring, n: cint): ErrCode {.ncurses_default, importc: "addnstr".}
-proc waddstr*(win: PWindow; str: cstring): ErrCode {.ncurses_default, importc: "waddstr".}
+proc addnstr*(str: cstring, n: cint): ErrCode {.cdecl, importc, discardable, dynlib: libncurses.}
+proc waddstr*(win: PWindow; str: cstring): ErrCode {.cdecl, importc, discardable, dynlib: libncurses.}
   ## Writes a string to the specified window.
   ## @Param: 'destinationWindow' the window to write the string to.
   ## @Param: 'stringToWrite'
   ## @Returns: ERR on failure and OK upon successful completion.
-proc waddnstr*(win: PWindow, str: cstring, n: cint): ErrCode {.ncurses_default, importc: "waddnstr".}
-proc mvaddstr*(y, x: cint; str: cstring): ErrCode {.ncurses_default, importc: "mvaddstr".}
+proc waddnstr*(win: PWindow, str: cstring, n: cint): ErrCode {.cdecl, importc, discardable, dynlib: libncurses.}
+proc mvaddstr*(y, x: cint; str: cstring): ErrCode {.cdecl, importc, discardable, dynlib: libncurses.}
   ## Moves the cursor to the specified position and outputs the provided string.
   ## The cursor is then advanced to the next position.
   ## @Param: 'y' the line to move the cursor to.
   ## @Param: 'x' the column to move the cursor to.
   ## @Param: 'stringToOutput' the string to put into the current window.
   ## @Returns: ERR on failure and OK upon successful completion.
-proc mvaddnstr*(y, x: cint, str: cstring, n: cint): ErrCode {.ncurses_default, importc: "mvaddnstr".}
-proc mvwaddstr*(win: PWindow, y, x: int, str: cstring): ErrCode {.ncurses_default, importc: "mvwaddstr".}
-proc mvwaddnstr*(win: PWindow, y, x: int, str: cstring, n: cint): ErrCode {.ncurses_default, importc: "mvwaddnstr".}
+proc mvaddnstr*(y, x: cint, str: cstring, n: cint): ErrCode {.cdecl, importc, discardable, dynlib: libncurses.}
+proc mvwaddstr*(win: PWindow, y, x: int, str: cstring): ErrCode {.cdecl, importc, discardable, dynlib: libncurses.}
+proc mvwaddnstr*(win: PWindow, y, x: int, str: cstring, n: cint): ErrCode {.cdecl, importc, discardable, dynlib: libncurses.}
 
 #addwstr: Adding a string of wide characters to a window (WideCString)
-proc addwstr(wstr: WideCString): ErrCode {.ncurses_default, importc: "addwstr".}
-proc addnwstr(wstr: WideCString, n: cint): ErrCode {.ncurses_default, importc: "addnwstr".}
-proc waddwstr(win: PWindow, wstr: WideCString): ErrCode {.ncurses_default, importc: "waddwstr".}
-proc waddnwstr(win: PWindow, wstr: WideCString, n: cint): ErrCode {.ncurses_default, importc: "waddnwstr".}
-proc mvaddwstr(y, x: cint, win: PWindow, wstr: WideCString): ErrCode {.ncurses_default, importc: "mvaddwstr".}
-proc mvaddnwstr(y, x: cint, win: PWindow, wstr: WideCString, n: cint): ErrCode {.ncurses_default, importc: "mvaddnwstr".}
-proc mvwaddwstr(win: PWindow, y, x: cint, wstr: WideCString): ErrCode {.ncurses_default, importc: "mvwaddwstr".}
-proc mvwaddnwstr(win: PWindow, y, x: cint, wstr: WideCString, n: cint): ErrCode {.ncurses_default, importc: "mvwaddnwstr".}
+proc addwstr(wstr: WideCString): ErrCode {.cdecl, importc, discardable, dynlib: libncurses.}
+proc addnwstr(wstr: WideCString, n: cint): ErrCode {.cdecl, importc, discardable, dynlib: libncurses.}
+proc waddwstr(win: PWindow, wstr: WideCString): ErrCode {.cdecl, importc, discardable, dynlib: libncurses.}
+proc waddnwstr(win: PWindow, wstr: WideCString, n: cint): ErrCode {.cdecl, importc, discardable, dynlib: libncurses.}
+proc mvaddwstr(y, x: cint, win: PWindow, wstr: WideCString): ErrCode {.cdecl, importc, discardable, dynlib: libncurses.}
+proc mvaddnwstr(y, x: cint, win: PWindow, wstr: WideCString, n: cint): ErrCode {.cdecl, importc, discardable, dynlib: libncurses.}
+proc mvwaddwstr(win: PWindow, y, x: cint, wstr: WideCString): ErrCode {.cdecl, importc, discardable, dynlib: libncurses.}
+proc mvwaddnwstr(win: PWindow, y, x: cint, wstr: WideCString, n: cint): ErrCode {.cdecl, importc, discardable, dynlib: libncurses.}
 
 #new_pair: Color-pair functions
-proc alloc_pair*(fg, bg: cint): ErrCode {.ncurses_default, importc: "".}
-proc find_pair*(fg, bg: cint): ErrCode {.ncurses_default, importc: "".}
-proc free_pair*(pair: cint): ErrCode {.ncurses_default, importc: "".}
+proc alloc_pair*(fg, bg: cint): ErrCode {.cdecl, importc, discardable, dynlib: libncurses.}
+proc find_pair*(fg, bg: cint): ErrCode {.cdecl, importc, discardable, dynlib: libncurses.}
+proc free_pair*(pair: cint): ErrCode {.cdecl, importc, discardable, dynlib: libncurses.}
 
 #default_colors: Use terminal's default colors
-proc use_default_colors*(): ErrCode {.ncurses_default, importc: "use_default_colors".}
-proc assume_default_colors*(fg, bg: cint): ErrCode {.ncurses_default, importc: "assume_default_colors".}
+proc use_default_colors*(): ErrCode {.cdecl, importc, discardable, dynlib: libncurses.}
+proc assume_default_colors*(fg, bg: cint): ErrCode {.cdecl, importc, discardable, dynlib: libncurses.}
 
 #attr: Character and attribute control routines
 const NCURSES_ATTR_SHIFT = 8'i64
@@ -255,187 +254,187 @@ const
   A_VERTICAL*    = NCURSES_BITS(u1, 21) #1073741824
   A_ITALIC*      = NCURSES_BITS(u1, 22) #2147483648
 
-proc attr_get*(attrs: ptr attr_t, pair: ptr cshort, opts: pointer): ErrCode {.ncurses_default, importc: "attr_get".}
-proc wattr_get*(win: PWindow, attrs: ptr attr_t, pair: ptr cshort, opts: pointer): ErrCode {.ncurses_default, importc: "wattr_get".}
-proc attr_set*(attrs: attr_t, pair: cshort, opts: pointer): ErrCode {.ncurses_default, importc: "attr_set".}
-proc wattr_set*(win: PWindow, attrs: attr_t, pair: cshort, opts: pointer): ErrCode {.ncurses_default, importc: "wattr_set".}
-proc attr_off*(attrs: attr_t, opts: pointer): ErrCode {.ncurses_default, importc: "attr_off".}
-proc wattr_off*(win: PWindow, attrs: attr_t, opts: pointer): ErrCode {.ncurses_default, importc: "wattr_off".}
-proc attr_on*(attrs: attr_t, opts: pointer): ErrCode {.ncurses_default, importc: "attr_on".}
-proc wattr_on*(win: PWindow, attrs: attr_t, opts: pointer): ErrCode {.ncurses_default, importc: "wattr_on".}
-proc attroff*(attrs: cint): ErrCode {.ncurses_default, importc: "attroff".}
+proc attr_get*(attrs: ptr attr_t, pair: ptr cshort, opts: pointer): ErrCode {.cdecl, importc, discardable, dynlib: libncurses.}
+proc wattr_get*(win: PWindow, attrs: ptr attr_t, pair: ptr cshort, opts: pointer): ErrCode {.cdecl, importc, discardable, dynlib: libncurses.}
+proc attr_set*(attrs: attr_t, pair: cshort, opts: pointer): ErrCode {.cdecl, importc, discardable, dynlib: libncurses.}
+proc wattr_set*(win: PWindow, attrs: attr_t, pair: cshort, opts: pointer): ErrCode {.cdecl, importc, discardable, dynlib: libncurses.}
+proc attr_off*(attrs: attr_t, opts: pointer): ErrCode {.cdecl, importc, discardable, dynlib: libncurses.}
+proc wattr_off*(win: PWindow, attrs: attr_t, opts: pointer): ErrCode {.cdecl, importc, discardable, dynlib: libncurses.}
+proc attr_on*(attrs: attr_t, opts: pointer): ErrCode {.cdecl, importc, discardable, dynlib: libncurses.}
+proc wattr_on*(win: PWindow, attrs: attr_t, opts: pointer): ErrCode {.cdecl, importc, discardable, dynlib: libncurses.}
+proc attroff*(attrs: cint): ErrCode {.cdecl, importc, discardable, dynlib: libncurses.}
   ## Turns off the named attributes without affecting any other attributes.
   ## @Param: 'attributes' the attributes to turn off for the current window.
   ## @Returns: An integer value, but the returned value does not have any meaning and can
   ## thus be ignored.
-proc wattroff*(win: PWindow, attrs: cint): ErrCode {.ncurses_default, importc: "wattroff".}
-proc attron*(attrs: cint): ErrCode {.ncurses_default, importc: "attron".}
+proc wattroff*(win: PWindow, attrs: cint): ErrCode {.cdecl, importc, discardable, dynlib: libncurses.}
+proc attron*(attrs: cint): ErrCode {.cdecl, importc, discardable, dynlib: libncurses.}
   ## Turns on the named attributes without affecting any other attributes.
   ## @Param: 'attributes' the attributes to turn on for the current window.
   ## @Returns: An integer value, but the returned value does not have any meaning and can
   ## thus be ignored.
-proc wattron*(win: PWindow, attrs: cint): ErrCode {.ncurses_default, importc: "wattron".}
-proc attrset*(attrs: cint): ErrCode {.ncurses_default, importc: "attrset".}
+proc wattron*(win: PWindow, attrs: cint): ErrCode {.cdecl, importc, discardable, dynlib: libncurses.}
+proc attrset*(attrs: cint): ErrCode {.cdecl, importc, discardable, dynlib: libncurses.}
   ## Sets the current attributes of the given window to the provided attributes.
   ## @Param: 'attributes', the attributes to apply to the current window.
   ## @Returns: An integer value, but the returned value does not have any meaning and can
   ## thus be ignored.
-proc wattrset*(win: PWindow, attrs: cint): ErrCode {.ncurses_default, importc: "wattrset".}
-proc chgat*(n: cint, attr: attr_t, pair: cshort, opts: pointer): ErrCode {.ncurses_default, importc: "chgat".}
-proc wchgat*(win: PWindow, n: cint, attr: attr_t, pair: cshort, opts: pointer): ErrCode {.ncurses_default, importc: "wchgat".}
-proc mvchgat*(y, x: cint, n: cint, attr: attr_t, pair: cshort, opts: pointer): ErrCode {.ncurses_default, importc: "mvchgat".}
-proc mvwchgat*(win: PWindow, y, x: cint, n: cint, attr: attr_t, pair: cshort, opts: pointer): ErrCode {.ncurses_default, importc: "mvwchgat".}
-proc color_set*(pair: cshort, opts: pointer): ErrCode {.ncurses_default, importc: "color_set".}
-proc wcolor_set*(win: PWindow, pair: cshort, opts: pointer): ErrCode {.ncurses_default, importc: "wcolor_set".}
-proc standend(): ErrCode {.ncurses_default, importc: "standend".}
-proc wstandend*(win: PWindow): ErrCode {.ncurses_default, importc: "wstandend".}
-proc standout*(): ErrCode {.ncurses_default, importc: "standout".}
-proc wstandout*(win: PWindow): ErrCode {.ncurses_default, importc: "wstandout".}
+proc wattrset*(win: PWindow, attrs: cint): ErrCode {.cdecl, importc, discardable, dynlib: libncurses.}
+proc chgat*(n: cint, attr: attr_t, pair: cshort, opts: pointer): ErrCode {.cdecl, importc, discardable, dynlib: libncurses.}
+proc wchgat*(win: PWindow, n: cint, attr: attr_t, pair: cshort, opts: pointer): ErrCode {.cdecl, importc, discardable, dynlib: libncurses.}
+proc mvchgat*(y, x: cint, n: cint, attr: attr_t, pair: cshort, opts: pointer): ErrCode {.cdecl, importc, discardable, dynlib: libncurses.}
+proc mvwchgat*(win: PWindow, y, x: cint, n: cint, attr: attr_t, pair: cshort, opts: pointer): ErrCode {.cdecl, importc, discardable, dynlib: libncurses.}
+proc color_set*(pair: cshort, opts: pointer): ErrCode {.cdecl, importc, discardable, dynlib: libncurses.}
+proc wcolor_set*(win: PWindow, pair: cshort, opts: pointer): ErrCode {.cdecl, importc, discardable, dynlib: libncurses.}
+proc standend(): ErrCode {.cdecl, importc, discardable, dynlib: libncurses.}
+proc wstandend*(win: PWindow): ErrCode {.cdecl, importc, discardable, dynlib: libncurses.}
+proc standout*(): ErrCode {.cdecl, importc, discardable, dynlib: libncurses.}
+proc wstandout*(win: PWindow): ErrCode {.cdecl, importc, discardable, dynlib: libncurses.}
 
 #termattrs: Enviroment query routines
-proc baudrate*(): cint {.ncurses_default, importc: "baudrate".}
-proc erasechar*() {.ncurses_default, importc: "erasechar".}
-proc erasewchar*(ch: WideCString) {.ncurses_default, importc: "erasewchar".}
-proc has_ic*(): bool {.ncurses_default, importc: "has_ic".}
-proc has_il*(): bool {.ncurses_default, importc: "has_il".}
-proc killchar*(): cchar {.ncurses_default, importc: "killchar".}
-proc killwchar*(ch: WideCString): char {.ncurses_default, importc: "killwchar".}
-proc longname*(): cstring {.ncurses_default, importc: "longname".}
-proc term_attrs*(): attr_t {.ncurses_default, importc: "term_attrs".}
-proc term_attrs_ch*(): chtype {.ncurses_default, importc: "termattrs".}
+proc baudrate*(): cint {.cdecl, importc, discardable, dynlib: libncurses.}
+proc erasechar*() {.cdecl, importc, discardable, dynlib: libncurses.}
+proc erasewchar*(ch: WideCString) {.cdecl, importc, discardable, dynlib: libncurses.}
+proc has_ic*(): bool {.cdecl, importc, discardable, dynlib: libncurses.}
+proc has_il*(): bool {.cdecl, importc, discardable, dynlib: libncurses.}
+proc killchar*(): cchar {.cdecl, importc, discardable, dynlib: libncurses.}
+proc killwchar*(ch: WideCString): char {.cdecl, importc, discardable, dynlib: libncurses.}
+proc longname*(): cstring {.cdecl, importc, discardable, dynlib: libncurses.}
+proc term_attrs*(): attr_t {.cdecl, importc, discardable, dynlib: libncurses.}
+proc term_attrs_ch*(): chtype {.cdecl, importc, discardable, dynlib: libncurses.}
   ## in C this function appears as termattr, although because of
   ## Nim's style insensitivity this had to be changed.
-proc termname*(): cstring {.ncurses_default, importc: "termname".}
+proc termname*(): cstring {.cdecl, importc, discardable, dynlib: libncurses.}
 
 #beep: Bell and screen flash routines
-proc beep*(): ErrCode {.ncurses_default, importc: "beep".}
-proc flash*(): ErrCode {.ncurses_default, importc: "flash".}
+proc beep*(): ErrCode {.cdecl, importc, discardable, dynlib: libncurses.}
+proc flash*(): ErrCode {.cdecl, importc, discardable, dynlib: libncurses.}
   ## Flashes the screen and if that is not possible it sounds the alert. If this is not possible
   ## nothing happens.
   ## @Returns: ERR on failure and OK upon successfully flashing.
 
 #bkgd: Window background manipulation routines
-proc bkgdset*(ch: chtype): void {.ncurses_default, importc: "bkgdset".}
-proc wbkgdset*(win: PWindow, ch: chtype): void {.ncurses_default, importc: "wbkgdset".}
-proc bkgd*(ch: chtype): ErrCode {.ncurses_default, importc: "bkgd".}
+proc bkgdset*(ch: chtype): void {.cdecl, importc, discardable, dynlib: libncurses.}
+proc wbkgdset*(win: PWindow, ch: chtype): void {.cdecl, importc, discardable, dynlib: libncurses.}
+proc bkgd*(ch: chtype): ErrCode {.cdecl, importc, discardable, dynlib: libncurses.}
   ## Sets the background property of the current window and apply this setting to every
   ## character position in the window.
   ## @Param: 'background' the background property to apply.
-proc wbkgd*(win: PWindow, ch: chtype): ErrCode {.ncurses_default, importc: "wbkgd".}
-proc getbkgd*(win: PWindow): chtype {.ncurses_default, importc: "getbkgd".}
+proc wbkgd*(win: PWindow, ch: chtype): ErrCode {.cdecl, importc, discardable, dynlib: libncurses.}
+proc getbkgd*(win: PWindow): chtype {.cdecl, importc, discardable, dynlib: libncurses.}
 
 #bkgrnd: Window complex background manipulation routines
-proc bkgrnd*(wch: cchar_t): ErrCode {.ncurses_default, importc: "bkgrnd".}
-proc wbkgrnd*(win: PWindow, wch: cchar_t): ErrCode {.ncurses_default, importc: "wbkgrnd".}
-proc bkgrndset*(wch: cchar_t): void {.ncurses_default, importc: "bkgrndset".}
-proc wbkgrndset*(win: PWindow, wch: cchar_t): void {.ncurses_default, importc: "getbkgrnd".}
-proc getbkgrnd*(wch: cchar_t): ErrCode {.ncurses_default, importc: "getbkgrnd".}
-proc wgetbkgrnd*(win: PWindow, wch: cchar_t): ErrCode {.ncurses_default, importc: "wgetbkgrnd".}
+proc bkgrnd*(wch: cchar_t): ErrCode {.cdecl, importc, discardable, dynlib: libncurses.}
+proc wbkgrnd*(win: PWindow, wch: cchar_t): ErrCode {.cdecl, importc, discardable, dynlib: libncurses.}
+proc bkgrndset*(wch: cchar_t): void {.cdecl, importc, discardable, dynlib: libncurses.}
+proc wbkgrndset*(win: PWindow, wch: cchar_t): void {.cdecl, importc, discardable, dynlib: libncurses.}
+proc getbkgrnd*(wch: cchar_t): ErrCode {.cdecl, importc, discardable, dynlib: libncurses.}
+proc wgetbkgrnd*(win: PWindow, wch: cchar_t): ErrCode {.cdecl, importc, discardable, dynlib: libncurses.}
 
 #border: Create borders, horizontal and vertical lines
-proc border*(ls, rs, ts, bs, tl, tr, bl, br: chtype): ErrCode {.ncurses_default, importc: "border".}
-proc wborder*(win: PWindow, ls, rs, ts, bs, tl, tr, bl, br: chtype): ErrCode {.ncurses_default, importc: "wborder".}
-proc box*(win: PWindow, verch, horch: chtype): ErrCode {.ncurses_default, importc: "box".}
-proc hline*(ch: chtype, n: cint): ErrCode {.ncurses_default, importc: "hline".}
-proc whline*(win: PWindow, ch: chtype, n: cint): ErrCode {.ncurses_default, importc: "whline".}
-proc vline*(ch: chtype, n: cint): ErrCode {.ncurses_default, importc: "vline".}
-proc wvline*(win: PWindow, ch: chtype, n: cint): ErrCode {.ncurses_default, importc: "wvline".}
-proc mvhline*(y, x: cint, ch: chtype, n: cint): ErrCode {.ncurses_default, importc: "mvhline".}
-proc mvwhline*(win: PWindow, y, x: cint, ch: chtype, n: cint): ErrCode {.ncurses_default, importc: "mvwhline".}
-proc mvvline*(y, x: cint, ch: chtype, n: cint): ErrCode {.ncurses_default, importc: "mvvline".}
-proc mvwvline*(win: PWindow, y, x: cint, ch: chtype, n: cint): ErrCode {.ncurses_default, importc: "mvwvline".}
+proc border*(ls, rs, ts, bs, tl, tr, bl, br: chtype): ErrCode {.cdecl, importc, discardable, dynlib: libncurses.}
+proc wborder*(win: PWindow, ls, rs, ts, bs, tl, tr, bl, br: chtype): ErrCode {.cdecl, importc, discardable, dynlib: libncurses.}
+proc box*(win: PWindow, verch, horch: chtype): ErrCode {.cdecl, importc, discardable, dynlib: libncurses.}
+proc hline*(ch: chtype, n: cint): ErrCode {.cdecl, importc, discardable, dynlib: libncurses.}
+proc whline*(win: PWindow, ch: chtype, n: cint): ErrCode {.cdecl, importc, discardable, dynlib: libncurses.}
+proc vline*(ch: chtype, n: cint): ErrCode {.cdecl, importc, discardable, dynlib: libncurses.}
+proc wvline*(win: PWindow, ch: chtype, n: cint): ErrCode {.cdecl, importc, discardable, dynlib: libncurses.}
+proc mvhline*(y, x: cint, ch: chtype, n: cint): ErrCode {.cdecl, importc, discardable, dynlib: libncurses.}
+proc mvwhline*(win: PWindow, y, x: cint, ch: chtype, n: cint): ErrCode {.cdecl, importc, discardable, dynlib: libncurses.}
+proc mvvline*(y, x: cint, ch: chtype, n: cint): ErrCode {.cdecl, importc, discardable, dynlib: libncurses.}
+proc mvwvline*(win: PWindow, y, x: cint, ch: chtype, n: cint): ErrCode {.cdecl, importc, discardable, dynlib: libncurses.}
 
 #borderset: Create borders or lines using complex characters and renditions
-proc border_set*(ls, rs, ts, bs, tl, tr, bl, br: cchar_t): ErrCode {.ncurses_default, importc: "border_set".}
-proc wborder_set*(win: PWindow, ls, rs, ts, bs, tl, tr, bl, br: cchar_t): ErrCode {.ncurses_default, importc: "wborder_set".}
-proc box_set*(win: PWindow, verch, horch: cchar_t): ErrCode {.ncurses_default, importc: "box_set".}
-proc hline_set*(wch: cchar_t, n: cint): ErrCode {.ncurses_default, importc: "hline_set".}
-proc whline_set*(win: PWindow, wch: cchar_t, n: cint): ErrCode {.ncurses_default, importc: "whline_set".}
-proc mvhline_set*(y,x: cint, wch: cchar_t, n: cint): ErrCode {.ncurses_default, importc: "mvhline_set".}
-proc mvwhline_set*(win: PWindow, y,x: cint, wch: cchar_t, n: cint): ErrCode {.ncurses_default, importc: "mvwhline_set".}
-proc vline_set*(wch: cchar_t, n: cint): ErrCode {.ncurses_default, importc: "vline_set".}
-proc wvline_set*(win: PWindow, wch: cchar_t, n: cint): ErrCode {.ncurses_default, importc: "wvline_set".}
-proc mvvline_set*(y,x: cint, wch: cchar_t, n: cint): ErrCode {.ncurses_default, importc: "mvvline_set".}
-proc mvwvline_set*(win: PWindow, y,x: cint, wch: cchar_t, n: cint): ErrCode {.ncurses_default, importc: "mvwvline_set".}
+proc border_set*(ls, rs, ts, bs, tl, tr, bl, br: cchar_t): ErrCode {.cdecl, importc, discardable, dynlib: libncurses.}
+proc wborder_set*(win: PWindow, ls, rs, ts, bs, tl, tr, bl, br: cchar_t): ErrCode {.cdecl, importc, discardable, dynlib: libncurses.}
+proc box_set*(win: PWindow, verch, horch: cchar_t): ErrCode {.cdecl, importc, discardable, dynlib: libncurses.}
+proc hline_set*(wch: cchar_t, n: cint): ErrCode {.cdecl, importc, discardable, dynlib: libncurses.}
+proc whline_set*(win: PWindow, wch: cchar_t, n: cint): ErrCode {.cdecl, importc, discardable, dynlib: libncurses.}
+proc mvhline_set*(y,x: cint, wch: cchar_t, n: cint): ErrCode {.cdecl, importc, discardable, dynlib: libncurses.}
+proc mvwhline_set*(win: PWindow, y,x: cint, wch: cchar_t, n: cint): ErrCode {.cdecl, importc, discardable, dynlib: libncurses.}
+proc vline_set*(wch: cchar_t, n: cint): ErrCode {.cdecl, importc, discardable, dynlib: libncurses.}
+proc wvline_set*(win: PWindow, wch: cchar_t, n: cint): ErrCode {.cdecl, importc, discardable, dynlib: libncurses.}
+proc mvvline_set*(y,x: cint, wch: cchar_t, n: cint): ErrCode {.cdecl, importc, discardable, dynlib: libncurses.}
+proc mvwvline_set*(win: PWindow, y,x: cint, wch: cchar_t, n: cint): ErrCode {.cdecl, importc, discardable, dynlib: libncurses.}
 
 #inopts: Input options
-proc cbreak*(): ErrCode {.ncurses_default, importc: "cbreak".}
+proc cbreak*(): ErrCode {.cdecl, importc, discardable, dynlib: libncurses.}
   ## The cbreak routine disables line buffering and erase/kill character-processing
   ## (interrupt and flow control characters are unaffected), making characters typed by
   ## the user immediately available to the program.
   ## @Returns: ERR on failure and OK upon successful completion.
-proc nocbreak*(): ErrCode {.ncurses_default, importc: "nocbreak".}
+proc nocbreak*(): ErrCode {.cdecl, importc, discardable, dynlib: libncurses.}
   ## Returns the terminal to normal (cooked mode).
   ## @Returns: ERR on failure and OK upon successful completion.
-proc noecho*(): ErrCode {.ncurses_default, importc: "noecho".}
-proc onecho*(): ErrCode {.ncurses_default, importc: "echo".}
+proc noecho*(): ErrCode {.cdecl, importc, discardable, dynlib: libncurses.}
+proc onecho*(): ErrCode {.cdecl, discardable, dynlib: libncurses, importc: "echo".}
   ## Previously `echo`, but this being a Nim's print function, is changed to `onecho`
-proc halfdelay*(tenths: cint): ErrCode {.ncurses_default, importc: "halfdelay".}
-proc keypad*(win: PWindow, bf: bool): cint {.ncurses_default, importc: "keypad".}
-proc meta*(win: PWindow, bf: bool): ErrCode {.ncurses_default, importc: "meta".}
-proc nodelay*(win: PWindow, bf: bool): cint {.ncurses_default, importc: "nodelay".}
-proc raw*(): ErrCode {.ncurses_default, importc: "raw".}
-proc noraw*(): ErrCode {.ncurses_default, importc: "noraw".}
-proc noqiflush*(): void {.ncurses_default, importc: "noqiflush".}
-proc qiflush*(): void {.ncurses_default, importc: "qiflush".}
-proc notimeout*(): ErrCode {.ncurses_default, importc: "notimeout".}
-proc timeout*(delay: cint): void {.ncurses_default, importc: "timeout".}
-proc wtimeout*(win: PWindow, delay: cint): void {.ncurses_default, importc: "wtimeout".}
-proc typeahead*(fd: cint): ErrCode {.ncurses_default, importc: "typeahead".}
+proc halfdelay*(tenths: cint): ErrCode {.cdecl, importc, discardable, dynlib: libncurses.}
+proc keypad*(win: PWindow, bf: bool): cint {.cdecl, importc, discardable, dynlib: libncurses.}
+proc meta*(win: PWindow, bf: bool): ErrCode {.cdecl, importc, discardable, dynlib: libncurses.}
+proc nodelay*(win: PWindow, bf: bool): cint {.cdecl, importc, discardable, dynlib: libncurses.}
+proc raw*(): ErrCode {.cdecl, importc, discardable, dynlib: libncurses.}
+proc noraw*(): ErrCode {.cdecl, importc, discardable, dynlib: libncurses.}
+proc noqiflush*(): void {.cdecl, importc, discardable, dynlib: libncurses.}
+proc qiflush*(): void {.cdecl, importc, discardable, dynlib: libncurses.}
+proc notimeout*(): ErrCode {.cdecl, importc, discardable, dynlib: libncurses.}
+proc timeout*(delay: cint): void {.cdecl, importc, discardable, dynlib: libncurses.}
+proc wtimeout*(win: PWindow, delay: cint): void {.cdecl, importc, discardable, dynlib: libncurses.}
+proc typeahead*(fd: cint): ErrCode {.cdecl, importc, discardable, dynlib: libncurses.}
 
 #clear: Clear all or part of a window
-proc erase*(): ErrCode {.ncurses_default, importc: "erase".}
-proc werase*(win: PWindow): ErrCode {.ncurses_default, importc: "werase".}
-proc clear*(): ErrCode {.ncurses_default, importc: "clear".}
-proc wclear*(win: PWindow): ErrCode {.ncurses_default, importc: "wclear".}
-proc clrtobot*(): ErrCode {.ncurses_default, importc: "clrtobot".}
-proc wclrtobot*(win: PWindow): ErrCode {.ncurses_default, importc: "wclrtobot".}
-proc clrtoeol*(): ErrCode {.ncurses_default, importc: "clrtoeol".}
-proc wclrtoeol*(win: PWindow): ErrCode {.ncurses_default, importc: "wclrtoeol".}
+proc erase*(): ErrCode {.cdecl, importc, discardable, dynlib: libncurses.}
+proc werase*(win: PWindow): ErrCode {.cdecl, importc, discardable, dynlib: libncurses.}
+proc clear*(): ErrCode {.cdecl, importc, discardable, dynlib: libncurses.}
+proc wclear*(win: PWindow): ErrCode {.cdecl, importc, discardable, dynlib: libncurses.}
+proc clrtobot*(): ErrCode {.cdecl, importc, discardable, dynlib: libncurses.}
+proc wclrtobot*(win: PWindow): ErrCode {.cdecl, importc, discardable, dynlib: libncurses.}
+proc clrtoeol*(): ErrCode {.cdecl, importc, discardable, dynlib: libncurses.}
+proc wclrtoeol*(win: PWindow): ErrCode {.cdecl, importc, discardable, dynlib: libncurses.}
 
 #outopts: Output options
-proc clearok*(win: PWindow, bf: bool): ErrCode {.ncurses_default, importc: "clearok".}
-proc idlok*(win: PWindow, bf: bool): ErrCode {.ncurses_default, importc: "idlok".}
-proc idcok*(win: PWindow, bf: bool): void {.ncurses_default, importc: "idcok".}
-proc immedok*(win: PWindow, bf: bool): void {.ncurses_default, importc: "immedok".}
-proc leaveok*(win: PWindow, bf: bool): ErrCode {.ncurses_default, importc: "leaveok".}
-proc setscrreg*(top, bot: cint): ErrCode {.ncurses_default, importc: "setscrreg".}
-proc wsetscrreg*(win: PWindow, top, bot: cint): ErrCode {.ncurses_default, importc: "wsetscrreg".}
-proc scrollok*(win: PWindow, bf: bool): ErrCode {.ncurses_default, importc: "scrollok".}
-proc nl*(): ErrCode {.ncurses_default, importc: "nl".}
-proc nonl*(): ErrCode {.ncurses_default, importc: "nonl".}
+proc clearok*(win: PWindow, bf: bool): ErrCode {.cdecl, importc, discardable, dynlib: libncurses.}
+proc idlok*(win: PWindow, bf: bool): ErrCode {.cdecl, importc, discardable, dynlib: libncurses.}
+proc idcok*(win: PWindow, bf: bool): void {.cdecl, importc, discardable, dynlib: libncurses.}
+proc immedok*(win: PWindow, bf: bool): void {.cdecl, importc, discardable, dynlib: libncurses.}
+proc leaveok*(win: PWindow, bf: bool): ErrCode {.cdecl, importc, discardable, dynlib: libncurses.}
+proc setscrreg*(top, bot: cint): ErrCode {.cdecl, importc, discardable, dynlib: libncurses.}
+proc wsetscrreg*(win: PWindow, top, bot: cint): ErrCode {.cdecl, importc, discardable, dynlib: libncurses.}
+proc scrollok*(win: PWindow, bf: bool): ErrCode {.cdecl, importc, discardable, dynlib: libncurses.}
+proc nl*(): ErrCode {.cdecl, importc, discardable, dynlib: libncurses.}
+proc nonl*(): ErrCode {.cdecl, importc, discardable, dynlib: libncurses.}
 
 #overlay: overlay and manipulate overlapped windows
-proc overlay*(srcwin, dstwin: PWindow): ErrCode {.ncurses_default, importc: "overlay".}
-proc overwrite*(srcwin, dstwin: PWindow): ErrCode {.ncurses_default, importc: "overwrite".}
+proc overlay*(srcwin, dstwin: PWindow): ErrCode {.cdecl, importc, discardable, dynlib: libncurses.}
+proc overwrite*(srcwin, dstwin: PWindow): ErrCode {.cdecl, importc, discardable, dynlib: libncurses.}
 proc copywin*(srcwin, dstwin: PWindow,
   sminrow, smincol,
   dminrow, dmincol,
   dmaxrow, dmaxcol: cint
-): ErrCode {.ncurses_default, importc: "copywin".}
+): ErrCode {.cdecl, importc, discardable, dynlib: libncurses.}
 
 #kernel: low-level routines (all except cur_set will always return OK)
-proc def_prog_mode*(): ErrCode {.ncurses_default, importc: "def_prog_mode".}
-proc def_shell_mode*(): ErrCode {.ncurses_default, importc: "def_shell_mode".}
-proc reset_prog_mode*(): ErrCode {.ncurses_default, importc: "reset_prog_mode".}
-proc reset_shell_mode*(): ErrCode {.ncurses_default, importc: "reset_shell_mode".}
-proc resetty*(): ErrCode {.ncurses_default, importc: "resetty".}
-proc savetty*(): ErrCode {.ncurses_default, importc: "savetty".}
-proc getsyx*(y,x: cint): void {.ncurses_default, importc: "getsyx".}
-proc setsyx*(y,x: cint): void {.ncurses_default, importc: "setsyx".}
-proc ripoffline*(line: cint, init: proc(win: PWindow, cols: cint): cint): ErrCode {.ncurses_default, importc: "ripoffline".}
-proc curs_set*(visibility: cint): cint {.ncurses_default, importc: "curs_set".}
-proc napms*(ms: cint): cint {.ncurses_default, importc: "napms".}
+proc def_prog_mode*(): ErrCode {.cdecl, importc, discardable, dynlib: libncurses.}
+proc def_shell_mode*(): ErrCode {.cdecl, importc, discardable, dynlib: libncurses.}
+proc reset_prog_mode*(): ErrCode {.cdecl, importc, discardable, dynlib: libncurses.}
+proc reset_shell_mode*(): ErrCode {.cdecl, importc, discardable, dynlib: libncurses.}
+proc resetty*(): ErrCode {.cdecl, importc, discardable, dynlib: libncurses.}
+proc savetty*(): ErrCode {.cdecl, importc, discardable, dynlib: libncurses.}
+proc getsyx*(y,x: cint): void {.cdecl, importc, discardable, dynlib: libncurses.}
+proc setsyx*(y,x: cint): void {.cdecl, importc, discardable, dynlib: libncurses.}
+proc ripoffline*(line: cint, init: proc(win: PWindow, cols: cint): cint): ErrCode {.cdecl, importc, discardable, dynlib: libncurses.}
+proc curs_set*(visibility: cint): cint {.cdecl, importc, discardable, dynlib: libncurses.}
+proc napms*(ms: cint): cint {.cdecl, importc, discardable, dynlib: libncurses.}
     ## Used to sleep for the specified milliseconds.
     ## @Params: 'milliseconds' the number of milliseconds to sleep for.
     ## @Returns: ERR on failure and OK upon successful completion.
 
 #extend: misc extensions
-proc curses_version*(): cstring {.ncurses_default, importc: "curses_version".}
-proc use_extended_names*(enable: bool): cint {.ncurses_default, importc: "use_extended_names".}
+proc curses_version*(): cstring {.cdecl, importc, discardable, dynlib: libncurses.}
+proc use_extended_names*(enable: bool): cint {.cdecl, importc, discardable, dynlib: libncurses.}
 
 #define_key: define a keycode
-proc define_key*(definition: cstring, keycode: cint): ErrCode {.ncurses_default, importc: "define_key".}
+proc define_key*(definition: cstring, keycode: cint): ErrCode {.cdecl, importc, discardable, dynlib: libncurses.}
 
 #terminfo: interfaces to terminfo database
 #[
@@ -450,7 +449,7 @@ type
     num_Booleans, num_Numbers, num_Strings: cushort
     ext_Booleans, ext_Numbers, ext_Strings: cushort
   TermType2 = TermType
-  Terminal {.ncurses_default, importc: "struct TERMINAL".} = object
+  Terminal {.cdecl, importc, discardable, dynlib: libncurses.} = object
     `type`: TERMTYPE
     filedes: cshort #yeaaaaah don't feel like adding terminfo
   #if interested:
@@ -459,128 +458,128 @@ type
 ]#
 
 #util: misc utility routines
-proc unctrl*(c: chtype): cstring {.ncurses_default, importc: "unctrl".}
-proc wunctrl*(c: ptr cchar_t): WideCString {.ncurses_default, importc: "wunctrl".}
-proc keyname*(c: cint): cstring {.ncurses_default, importc: "keyname".}
-proc keyname_wch*(w: WideCString): cstring {.ncurses_default, importc: "key_name".} ## previously key_name, had to be renamed.
-proc filter*(): void {.ncurses_default, importc: "filter".}
-proc nofilter*(): void {.ncurses_default, importc: "nofilter".}
-proc use_env*(f: bool): void {.ncurses_default, importc: "use_env".}
-proc use_tioctl*(f: bool): void {.ncurses_default, importc: "use_tioctl".}
-proc putwin*(win: PWindow, filep: File): ErrCode {.ncurses_default, importc: "putwin".}
-proc getwin*(filep: File): PWindow {.ncurses_default, importc: "getwin".}
-proc delay_output*(ms: cint): ErrCode {.ncurses_default, importc: "delay_output".}
-proc flushinp*(): cint {.ncurses_default, importc: "flushinp".}
+proc unctrl*(c: chtype): cstring {.cdecl, importc, discardable, dynlib: libncurses.}
+proc wunctrl*(c: ptr cchar_t): WideCString {.cdecl, importc, discardable, dynlib: libncurses.}
+proc keyname*(c: cint): cstring {.cdecl, importc, discardable, dynlib: libncurses.}
+proc keyname_wch*(w: WideCString): cstring {.cdecl, discardable, dynlib: libncurses, importc: "key_name".} ## previously key_name, had to be renamed.
+proc filter*(): void {.cdecl, importc, discardable, dynlib: libncurses.}
+proc nofilter*(): void {.cdecl, importc, discardable, dynlib: libncurses.}
+proc use_env*(f: bool): void {.cdecl, importc, discardable, dynlib: libncurses.}
+proc use_tioctl*(f: bool): void {.cdecl, importc, discardable, dynlib: libncurses.}
+proc putwin*(win: PWindow, filep: File): ErrCode {.cdecl, importc, discardable, dynlib: libncurses.}
+proc getwin*(filep: File): PWindow {.cdecl, importc, discardable, dynlib: libncurses.}
+proc delay_output*(ms: cint): ErrCode {.cdecl, importc, discardable, dynlib: libncurses.}
+proc flushinp*(): cint {.cdecl, importc, discardable, dynlib: libncurses.}
 
 #delch: delete character under the cursor in a window
-proc delch*(): cint {.ncurses_default, importc: "delch".}
+proc delch*(): cint {.cdecl, importc, discardable, dynlib: libncurses.}
   ## Delete the character under the cursor in the stdscr.
   ## @Returns: ERR on failure and OK upon successfully flashing.
-proc wdelch*(win: PWindow): ErrCode {.ncurses_default, importc: "wdelch".}
-proc mvdelch*(y,x: cint): ErrCode {.ncurses_default, importc: "mvdelch".}
-proc mvwdelch*(win: PWindow, y,x: cint): ErrCode {.ncurses_default, importc: "mvwdelch".}
+proc wdelch*(win: PWindow): ErrCode {.cdecl, importc, discardable, dynlib: libncurses.}
+proc mvdelch*(y,x: cint): ErrCode {.cdecl, importc, discardable, dynlib: libncurses.}
+proc mvwdelch*(win: PWindow, y,x: cint): ErrCode {.cdecl, importc, discardable, dynlib: libncurses.}
 
 #deleteln: delete and insert lines in a window
-proc deleteln*(): cint {.ncurses_default, importc: "deleteln".}
+proc deleteln*(): cint {.cdecl, importc, discardable, dynlib: libncurses.}
   ## Deletes the line under the cursor in the stdscr. All lines below the current line are moved up one line.
   ## The bottom line of the window is cleared and the cursor position does not change.
   ## @Returns: ERR on failure and OK upon successful completion.
-proc wdeleteln*(win: PWindow): ErrCode {.ncurses_default, importc: "wdeleteln".}
-proc insdeln*(): ErrCode {.ncurses_default, importc: "insdeln".}
-proc winsdeln*(win: PWindow, n: int): ErrCode {.ncurses_default, importc: "winsdeln".}
-proc insertln*(): cint {.ncurses_default, importc: "insertln".}
+proc wdeleteln*(win: PWindow): ErrCode {.cdecl, importc, discardable, dynlib: libncurses.}
+proc insdeln*(): ErrCode {.cdecl, importc, discardable, dynlib: libncurses.}
+proc winsdeln*(win: PWindow, n: int): ErrCode {.cdecl, importc, discardable, dynlib: libncurses.}
+proc insertln*(): cint {.cdecl, importc, discardable, dynlib: libncurses.}
   ## Inserts a blank line above the current line in stdscr and the bottom line is lost.
   ## @Returns: ERR on failure and OK upon successful completion.
-proc winsertln*(win: PWindow): ErrCode {.ncurses_default, importc: "winsertln".}
+proc winsertln*(win: PWindow): ErrCode {.cdecl, importc, discardable, dynlib: libncurses.}
 
 #iniscr: screen initialization and manipulation routines
-proc initscr*(): PWindow {.ncurses_default, importc: "initscr".}
+proc initscr*(): PWindow {.cdecl, importc, discardable, dynlib: libncurses.}
   ## Usually the first curses routine to be called when initialising a program
   ## The initscr code determines the terminal type and initialises  all curses data structures.  initscr also causes the
   ## first call to refresh to clear the screen.
   ## @Returns: A pointer to stdscr is returned if the operation is successful.
   ## @Note: If errors occur, initscr writes an appropriate error message to
   ## standard error and exits.
-proc endwin*(): ErrCode {.ncurses_default, importc: "endwin".}
+proc endwin*(): ErrCode {.cdecl, importc, discardable, dynlib: libncurses.}
   ## A program should always call endwin before exiting or escaping from curses mode temporarily. This routine
   ## restores tty modes, moves the cursor to the lower left-hand corner of the screen and resets the terminal into the
   ## proper non-visual mode. Calling refresh or doupdate after a temporary escape causes the program to resume visual mode.
   ## @Returns: ERR on failure and OK upon successful completion.
-proc isendwin*(): bool {.ncurses_default, importc: "isendwin".}
-proc newterm*(`type`: cstring, outfd, infd: File): ptr Screen {.ncurses_default, importc: "newterm".}
-proc set_term*(`new`: ptr Screen): ptr Screen {.ncurses_default, importc: "set_term".}
-proc delscreen*(sp: ptr Screen): void {.ncurses_default, importc: "delscreen".}
+proc isendwin*(): bool {.cdecl, importc, discardable, dynlib: libncurses.}
+proc newterm*(`type`: cstring, outfd, infd: File): ptr Screen {.cdecl, importc, discardable, dynlib: libncurses.}
+proc set_term*(`new`: ptr Screen): ptr Screen {.cdecl, importc, discardable, dynlib: libncurses.}
+proc delscreen*(sp: ptr Screen): void {.cdecl, importc, discardable, dynlib: libncurses.}
 
 #window: create a window
-proc newwin*(nlines, ncols, begin_y, begin_x: cint): PWindow {.ncurses_default, importc: "newwin".}
-proc delwin*(win: PWindow): ErrCode {.ncurses_default, importc: "delwin".}
-proc mvwin*(win: PWindow, y,x: cint): ErrCode {.ncurses_default, importc: "mvwin".}
-proc subwin*(orig: PWindow, nlines, ncols, begin_y, begin_x: cint): PWindow {.ncurses_default, importc: "subwin".}
-proc derwin*(orig: PWindow, nlines, ncols, begin_y, begin_x: cint): PWindow {.ncurses_default, importc: "derwin".}
-proc mvderwin*(win: PWindow, par_y, par_x: cint): ErrCode {.ncurses_default, importc: "mvderwin".}
-proc dupwin*(win: PWindow): PWindow {.ncurses_default, importc: "dupwin".}
-proc wsyncup*(win: PWindow): void {.ncurses_default, importc: "wsyncup".}
-proc syncok*(win: PWindow, bf: bool): ErrCode {.ncurses_default, importc: "syncok".}
-proc wcursyncup*(win: PWindow): void {.ncurses_default, importc: "wcursynup".}
-proc wsyncdown*(win: PWindow): void {.ncurses_default, importc: "wsyncdown".}
+proc newwin*(nlines, ncols, begin_y, begin_x: cint): PWindow {.cdecl, importc, discardable, dynlib: libncurses.}
+proc delwin*(win: PWindow): ErrCode {.cdecl, importc, discardable, dynlib: libncurses.}
+proc mvwin*(win: PWindow, y,x: cint): ErrCode {.cdecl, importc, discardable, dynlib: libncurses.}
+proc subwin*(orig: PWindow, nlines, ncols, begin_y, begin_x: cint): PWindow {.cdecl, importc, discardable, dynlib: libncurses.}
+proc derwin*(orig: PWindow, nlines, ncols, begin_y, begin_x: cint): PWindow {.cdecl, importc, discardable, dynlib: libncurses.}
+proc mvderwin*(win: PWindow, par_y, par_x: cint): ErrCode {.cdecl, importc, discardable, dynlib: libncurses.}
+proc dupwin*(win: PWindow): PWindow {.cdecl, importc, discardable, dynlib: libncurses.}
+proc wsyncup*(win: PWindow): void {.cdecl, importc, discardable, dynlib: libncurses.}
+proc syncok*(win: PWindow, bf: bool): ErrCode {.cdecl, importc, discardable, dynlib: libncurses.}
+proc wcursyncup*(win: PWindow): void {.cdecl, importc, discardable, dynlib: libncurses.}
+proc wsyncdown*(win: PWindow): void {.cdecl, importc, discardable, dynlib: libncurses.}
 
 #refresh: refresh windows and lines
-proc refresh*(): cint {.ncurses_default, importc: "refresh".}
+proc refresh*(): cint {.cdecl, importc, discardable, dynlib: libncurses.}
   ## Must be called to get actual output to the terminal. refresh uses stdscr has the default window.
   ## @Returns: ERR on failure and OK upon successful completion.
-proc wrefresh*(win: PWindow): cint {.ncurses_default, importc: "wrefresh".}
-proc wnoutrefresh*(win: PWindow): ErrCode {.ncurses_default, importc: "wnoutrefresh".}
-proc doupdate*(): ErrCode {.ncurses_default, importc: "doupdate".}
-proc redrawwin*(win: PWindow): ErrCode {.ncurses_default, importc: "redrawwin".}
-proc wredrawln*(win: PWindow, beg_lines, num_lines: cint): ErrCode {.ncurses_default, importc: "wredrawln".}
+proc wrefresh*(win: PWindow): cint {.cdecl, importc, discardable, dynlib: libncurses.}
+proc wnoutrefresh*(win: PWindow): ErrCode {.cdecl, importc, discardable, dynlib: libncurses.}
+proc doupdate*(): ErrCode {.cdecl, importc, discardable, dynlib: libncurses.}
+proc redrawwin*(win: PWindow): ErrCode {.cdecl, importc, discardable, dynlib: libncurses.}
+proc wredrawln*(win: PWindow, beg_lines, num_lines: cint): ErrCode {.cdecl, importc, discardable, dynlib: libncurses.}
 
 #slk: soft label routines
-proc slk_init*(fmt: cint): ErrCode {.ncurses_default, importc: "slk_init".}
-proc slk_set*(labnum: cint, label: WideCString, fmt: cint): ErrCode {.ncurses_default, importc: "slk_set".}
-proc slk_wset*(labnum: cint, label: WideCString, fmt: cint): ErrCode {.ncurses_default, importc: "slk_wset".}
-proc slk_label*(labnum: cint): cstring {.ncurses_default, importc: "slk_label".}
-proc slk_refresh*(): ErrCode {.ncurses_default, importc: "slk_refresh".}
-proc slk_noutrefresh*(): ErrCode {.ncurses_default, importc: "slk_noutrefresh".}
-proc slk_clear*(): ErrCode {.ncurses_default, importc: "slk_clear".}
-proc slk_restore*(): ErrCode {.ncurses_default, importc: "slk_restore".}
-proc slk_touch*(): ErrCode {.ncurses_default, importc: "slk_touch".}
-proc slk_attron_ch*(attrs: chtype): ErrCode {.ncurses_default, importc: "slk_attron".}
-proc slk_attroff_ch*(attrs: chtype): ErrCode {.ncurses_default, importc: "slk_attroff".}
-proc slk_attrset_ch*(attrs: chtype): ErrCode {.ncurses_default, importc: "slk_attrset".}
-proc slk_attr_on*(attrs: attr_t, opts: pointer): ErrCode {.ncurses_default, importc: "slk_attr_on".}
-proc slk_attr_off*(attrs: attr_t, opts: pointer): ErrCode {.ncurses_default, importc: "slk_attr_off".}
-proc slk_attr_set*(attrs: attr_t, pair: cshort, opts: pointer): ErrCode {.ncurses_default, importc: "slk_attr_set".}
-proc slk_attr*(): attr_t {.ncurses_default, importc: "slk_attr".}
-proc slk_color*(pair: cshort): ErrCode {.ncurses_default, importc: "slk_color".}
-proc extended_slk_color*(pair: cint): ErrCode {.ncurses_default, importc: "extended_slk_color".}
+proc slk_init*(fmt: cint): ErrCode {.cdecl, importc, discardable, dynlib: libncurses.}
+proc slk_set*(labnum: cint, label: WideCString, fmt: cint): ErrCode {.cdecl, importc, discardable, dynlib: libncurses.}
+proc slk_wset*(labnum: cint, label: WideCString, fmt: cint): ErrCode {.cdecl, importc, discardable, dynlib: libncurses.}
+proc slk_label*(labnum: cint): cstring {.cdecl, importc, discardable, dynlib: libncurses.}
+proc slk_refresh*(): ErrCode {.cdecl, importc, discardable, dynlib: libncurses.}
+proc slk_noutrefresh*(): ErrCode {.cdecl, importc, discardable, dynlib: libncurses.}
+proc slk_clear*(): ErrCode {.cdecl, importc, discardable, dynlib: libncurses.}
+proc slk_restore*(): ErrCode {.cdecl, importc, discardable, dynlib: libncurses.}
+proc slk_touch*(): ErrCode {.cdecl, importc, discardable, dynlib: libncurses.}
+proc slk_attron_ch*(attrs: chtype): ErrCode {.cdecl, importc, discardable, dynlib: libncurses.}
+proc slk_attroff_ch*(attrs: chtype): ErrCode {.cdecl, importc, discardable, dynlib: libncurses.}
+proc slk_attrset_ch*(attrs: chtype): ErrCode {.cdecl, importc, discardable, dynlib: libncurses.}
+proc slk_attr_on*(attrs: attr_t, opts: pointer): ErrCode {.cdecl, importc, discardable, dynlib: libncurses.}
+proc slk_attr_off*(attrs: attr_t, opts: pointer): ErrCode {.cdecl, importc, discardable, dynlib: libncurses.}
+proc slk_attr_set*(attrs: attr_t, pair: cshort, opts: pointer): ErrCode {.cdecl, importc, discardable, dynlib: libncurses.}
+proc slk_attr*(): attr_t {.cdecl, importc, discardable, dynlib: libncurses.}
+proc slk_color*(pair: cshort): ErrCode {.cdecl, importc, discardable, dynlib: libncurses.}
+proc extended_slk_color*(pair: cint): ErrCode {.cdecl, importc, discardable, dynlib: libncurses.}
 
 #get_wch: get (or push back) a wide character from a terminal keyboard
-proc get_wch*(wch: WideCString): ErrCode {.ncurses_default, importc: "get_wch".}
-proc wget_wch*(win: PWindow, wch: WideCString): ErrCode {.ncurses_default, importc: "wget_wsch".}
-proc mvget_wch*(y,x: cint, wch: WideCString): ErrCode {.ncurses_default, importc: "mvget_wch".}
-proc mvwget_wch*(win: PWindow, y,x: cint, wch: WideCString): ErrCode {.ncurses_default, importc: "mvwget_wch".}
-proc unget_wch*(wch: WideCString): ErrCode {.ncurses_default, importc: "unget_wch".}
+proc get_wch*(wch: WideCString): ErrCode {.cdecl, importc, discardable, dynlib: libncurses.}
+proc wget_wch*(win: PWindow, wch: WideCString): ErrCode {.cdecl, importc, discardable, dynlib: libncurses.}
+proc mvget_wch*(y,x: cint, wch: WideCString): ErrCode {.cdecl, importc, discardable, dynlib: libncurses.}
+proc mvwget_wch*(win: PWindow, y,x: cint, wch: WideCString): ErrCode {.cdecl, importc, discardable, dynlib: libncurses.}
+proc unget_wch*(wch: WideCString): ErrCode {.cdecl, importc, discardable, dynlib: libncurses.}
 
 #get_wstr: get an array of wide characters from a terminal keyboard
-proc get_wstr*(wstr: WideCString): ErrCode {.ncurses_default, importc: "get_wstr".}
-proc getn_wstr*(wstr: WideCString, n: cint): ErrCode {.ncurses_default, importc: "getn_wstr".}
-proc wget_wstr*(win: PWindow, wstr: WideCString): ErrCode {.ncurses_default, importc: "wget_wsch".}
-proc wgetn_wstr*(win: PWindow, wstr: WideCString, n: cint): ErrCode {.ncurses_default, importc: "wgetn_wsch".}
-proc mvget_wstr*(y,x: cint, wstr: WideCString): ErrCode {.ncurses_default, importc: "mvget_wstr".}
-proc mvgetn_wstr*(y,x: cint, wstr: WideCString, n: cint): ErrCode {.ncurses_default, importc: "mvgetn_wstr".}
-proc mvwget_wstr*(win: PWindow, y,x: cint, wstr: WideCString): ErrCode {.ncurses_default, importc: "mvwget_wstr".}
-proc mvwgetn_wstr*(win: PWindow, y,x: cint, wstr: WideCString, n: cint): ErrCode {.ncurses_default, importc: "mvwgetn_wstr".}
+proc get_wstr*(wstr: WideCString): ErrCode {.cdecl, importc, discardable, dynlib: libncurses.}
+proc getn_wstr*(wstr: WideCString, n: cint): ErrCode {.cdecl, importc, discardable, dynlib: libncurses.}
+proc wget_wstr*(win: PWindow, wstr: WideCString): ErrCode {.cdecl, importc, discardable, dynlib: libncurses.}
+proc wgetn_wstr*(win: PWindow, wstr: WideCString, n: cint): ErrCode {.cdecl, importc, discardable, dynlib: libncurses.}
+proc mvget_wstr*(y,x: cint, wstr: WideCString): ErrCode {.cdecl, importc, discardable, dynlib: libncurses.}
+proc mvgetn_wstr*(y,x: cint, wstr: WideCString, n: cint): ErrCode {.cdecl, importc, discardable, dynlib: libncurses.}
+proc mvwget_wstr*(win: PWindow, y,x: cint, wstr: WideCString): ErrCode {.cdecl, importc, discardable, dynlib: libncurses.}
+proc mvwgetn_wstr*(win: PWindow, y,x: cint, wstr: WideCString, n: cint): ErrCode {.cdecl, importc, discardable, dynlib: libncurses.}
 
 #legacy: get cursor and window coordinates, attributes
-proc getattrs*(win: PWindow): cint {.ncurses_default, importc: "getattrs".}
-proc getbegx*(win: PWindow): cint {.ncurses_default, importc: "getbegx".}
-proc getbegy*(win: PWindow): cint {.ncurses_default, importc: "getbegy".}
-proc getcurx*(win: PWindow): cint {.ncurses_default, importc: "getcurx".}
-proc getcury*(win: PWindow): cint {.ncurses_default, importc: "getcury".}
-proc getmaxx*(win: PWindow): cint {.ncurses_default, importc: "getmaxx".}
-proc getmaxy*(win: PWindow): cint {.ncurses_default, importc: "getmaxy".}
-proc getparx*(win: PWindow): cint {.ncurses_default, importc: "getparx".}
-proc getpary*(win: PWindow): cint {.ncurses_default, importc: "getpary".}
+proc getattrs*(win: PWindow): cint {.cdecl, importc, discardable, dynlib: libncurses.}
+proc getbegx*(win: PWindow): cint {.cdecl, importc, discardable, dynlib: libncurses.}
+proc getbegy*(win: PWindow): cint {.cdecl, importc, discardable, dynlib: libncurses.}
+proc getcurx*(win: PWindow): cint {.cdecl, importc, discardable, dynlib: libncurses.}
+proc getcury*(win: PWindow): cint {.cdecl, importc, discardable, dynlib: libncurses.}
+proc getmaxx*(win: PWindow): cint {.cdecl, importc, discardable, dynlib: libncurses.}
+proc getmaxy*(win: PWindow): cint {.cdecl, importc, discardable, dynlib: libncurses.}
+proc getparx*(win: PWindow): cint {.cdecl, importc, discardable, dynlib: libncurses.}
+proc getpary*(win: PWindow): cint {.cdecl, importc, discardable, dynlib: libncurses.}
 
 #getyx: get curses cursor and window coordinates (these are implemented as macros in ncurses.h)
 template getyx*(win: PWindow, y, x: cint): untyped=
@@ -601,206 +600,206 @@ template getparyx*(win: PWindow, y, x: cint): untyped=
   (y = getpary(win); x = getparx(win))
 
 #getcchar: Get a wide character string and rendition from cchar_t or set a cchar_t from a wide-character string
-proc getcchar*(wcval: ptr cchar_t, wch: WideCString, attrs: ptr attr_t, color_pair: ptr cshort, opts: pointer): ErrCode {.ncurses_default, importc: "getcchar".}
-proc setcchar*(wcval: ptr cchar_t, wch: WideCString, attrs: attr_t, color_pair: cshort, opts: pointer): ErrCode {.ncurses_default, importc: "setcchar".}
+proc getcchar*(wcval: ptr cchar_t, wch: WideCString, attrs: ptr attr_t, color_pair: ptr cshort, opts: pointer): ErrCode {.cdecl, importc, discardable, dynlib: libncurses.}
+proc setcchar*(wcval: ptr cchar_t, wch: WideCString, attrs: attr_t, color_pair: cshort, opts: pointer): ErrCode {.cdecl, importc, discardable, dynlib: libncurses.}
 
 #getch: get (or push back) characters from the terminal keyboard
-proc getch*(): ErrCode {.ncurses_default, importc: "getch".}
+proc getch*(): ErrCode {.cdecl, importc, discardable, dynlib: libncurses.}
   ## Read a character from the stdscr window.
   ## @Returns: ERR on failure and OK upon successful completion.
-proc wgetch*(win: PWindow): ErrCode {.ncurses_default, importc: "wgetch".}
+proc wgetch*(win: PWindow): ErrCode {.cdecl, importc, discardable, dynlib: libncurses.}
   ## Read a character from the specified window.
   ## @Param: 'sourceWindow' the window to read a character from.
   ## @Returns: ERR on failure and OK upon successful completion.
-proc mvgetch*(y,x: cint): ErrCode {.ncurses_default, importc: "mvgetch".}
-proc mvwgetch*(win: PWindow, y,x: cint): ErrCode {.ncurses_default, importc: "mvwgetch".}
-proc ungetch*(ch: cint): ErrCode {.ncurses_default, importc: "ungetch".}
-proc has_key*(ch: cint): ErrCode {.ncurses_default, importc: "has_key".}
+proc mvgetch*(y,x: cint): ErrCode {.cdecl, importc, discardable, dynlib: libncurses.}
+proc mvwgetch*(win: PWindow, y,x: cint): ErrCode {.cdecl, importc, discardable, dynlib: libncurses.}
+proc ungetch*(ch: cint): ErrCode {.cdecl, importc, discardable, dynlib: libncurses.}
+proc has_key*(ch: cint): ErrCode {.cdecl, importc, discardable, dynlib: libncurses.}
 
 #mouse: mouse interface
-proc has_mouse*(): bool {.ncurses_default, importc: "has_mouse".}
-proc getmouse*(event: ptr Mevent): ErrCode {.ncurses_default, importc: "getmouse".}
-proc ungetmouse*(event: ptr Mevent): ErrCode {.ncurses_default, importc: "ungetmouse".}
-proc mousemask*(newmask: mmask_t, oldmask: ptr mmask_t): mmask_t {.ncurses_default, importc: "mousemask".}
-proc wenclose*(win: PWindow, y, x: cint): bool {.ncurses_default, importc: "wenclose".}
-proc mouse_trafo*(y,x: ptr cint, to_screen: bool): bool {.ncurses_default, importc: "mouse_trafo".}
-proc wmouse_trafo*(win: PWindow, y,x: ptr cint, to_screen: bool): bool {.ncurses_default, importc: "wmouse_trafo".}
-proc mouseinterval*(erval: cint): ErrCode {.ncurses_default, importc: "mouseinterval".}
+proc has_mouse*(): bool {.cdecl, importc, discardable, dynlib: libncurses.}
+proc getmouse*(event: ptr Mevent): ErrCode {.cdecl, importc, discardable, dynlib: libncurses.}
+proc ungetmouse*(event: ptr Mevent): ErrCode {.cdecl, importc, discardable, dynlib: libncurses.}
+proc mousemask*(newmask: mmask_t, oldmask: ptr mmask_t): mmask_t {.cdecl, importc, discardable, dynlib: libncurses.}
+proc wenclose*(win: PWindow, y, x: cint): bool {.cdecl, importc, discardable, dynlib: libncurses.}
+proc mouse_trafo*(y,x: ptr cint, to_screen: bool): bool {.cdecl, importc, discardable, dynlib: libncurses.}
+proc wmouse_trafo*(win: PWindow, y,x: ptr cint, to_screen: bool): bool {.cdecl, importc, discardable, dynlib: libncurses.}
+proc mouseinterval*(erval: cint): ErrCode {.cdecl, importc, discardable, dynlib: libncurses.}
 
 #getstr: accept character strings from terminal keyboard
-proc getstr*(str: cstring): ErrCode {.ncurses_default, importc: "getstr".}
+proc getstr*(str: cstring): ErrCode {.cdecl, importc, discardable, dynlib: libncurses.}
   ## Reads the inputted characters into the provided string.
   ## @Param: 'inputString' the variable to read the input into.
   ## @Returns: ERR on failure and OK upon successful completion.
-proc getnstr*(str: cstring; n: cint): ErrCode {.ncurses_default, importc: "getnstr".}
+proc getnstr*(str: cstring; n: cint): ErrCode {.cdecl, importc, discardable, dynlib: libncurses.}
   ## Reads at most the specified number of characters into the provided string.
   ## @Param: 'inputString' the variable to read the input into.
   ## @Param: 'numberOfCharacters' the maximum number of characters to read.
   ## @Returns: ERR on failure and OK upon successful completion.
-proc wgetstr*(win: PWindow, str: cstring): ErrCode {.ncurses_default, importc: "wgetstr".}
-proc wgetnstr*(win: PWindow, str: cstring, n: cint): ErrCode {.ncurses_default, importc: "wgetnstr".}
-proc mvgetstr*(y,x: cint, str: cstring): ErrCode {.ncurses_default, importc: "mvgetstr".}
-proc mvgetnstr*(y,x: cint, str: cstring, n: cint): ErrCode {.ncurses_default, importc: "mvgetnstr".}
-proc mvwgetstr*(win: PWindow, y,x: cint, str: cstring): ErrCode {.ncurses_default, importc: "mvwgetstr".}
-proc mvwgetnstr*(win: PWindow, y,x: cint, str: cstring, n: cint): ErrCode {.ncurses_default, importc: "mvwgetnstr".}
+proc wgetstr*(win: PWindow, str: cstring): ErrCode {.cdecl, importc, discardable, dynlib: libncurses.}
+proc wgetnstr*(win: PWindow, str: cstring, n: cint): ErrCode {.cdecl, importc, discardable, dynlib: libncurses.}
+proc mvgetstr*(y,x: cint, str: cstring): ErrCode {.cdecl, importc, discardable, dynlib: libncurses.}
+proc mvgetnstr*(y,x: cint, str: cstring, n: cint): ErrCode {.cdecl, importc, discardable, dynlib: libncurses.}
+proc mvwgetstr*(win: PWindow, y,x: cint, str: cstring): ErrCode {.cdecl, importc, discardable, dynlib: libncurses.}
+proc mvwgetnstr*(win: PWindow, y,x: cint, str: cstring, n: cint): ErrCode {.cdecl, importc, discardable, dynlib: libncurses.}
 
 #in_wch: extract a complex character and rendition from a window
-proc in_wch*(wcval: ptr cchar_t): ErrCode {.ncurses_default, importc: "in_wch".}
-proc mvinwch*(y,x: cint, wcval: ptr cchar_t): ErrCode {.ncurses_default, importc: "mvin_wch".}
-proc mvwin_wch*(win: PWindow, y,x: cint, wcval: ptr cchar_t): ErrCode {.ncurses_default, importc: "mcwin_wch".}
-proc win_wch*(win: PWindow, wcval: ptr cchar_t): ErrCode {.ncurses_default, importc: "win_wch".}
+proc in_wch*(wcval: ptr cchar_t): ErrCode {.cdecl, importc, discardable, dynlib: libncurses.}
+proc mvinwch*(y,x: cint, wcval: ptr cchar_t): ErrCode {.cdecl, importc, discardable, dynlib: libncurses.}
+proc mvwin_wch*(win: PWindow, y,x: cint, wcval: ptr cchar_t): ErrCode {.cdecl, importc, discardable, dynlib: libncurses.}
+proc win_wch*(win: PWindow, wcval: ptr cchar_t): ErrCode {.cdecl, importc, discardable, dynlib: libncurses.}
 
 #in_wchstr: get an array of complex characters and renditions from a window
-proc in_wchstr*(wchstr: ptr cchar_t): ErrCode {.ncurses_default, importc: "in_wchstr".}
-proc in_wchnstr*(wchstr: ptr cchar_t, n: cint): ErrCode {.ncurses_default, importc: "in_wchnstr".}
-proc win_wchstr*(win: PWindow, wchstr: ptr cchar_t): ErrCode {.ncurses_default, importc: "win_wchstr".}
-proc win_wchnstr*(win: PWindow, wchstr: ptr cchar_t, n: cint): ErrCode {.ncurses_default, importc: "win_wchnstr".}
-proc mvin_wchstr*(y,x: cint, wchstr: ptr cchar_t): ErrCode {.ncurses_default, importc: "mvin_wchstr".}
-proc mvin_wchnstr*(y,x: cint, wchstr: ptr cchar_t, n: cint): ErrCode {.ncurses_default, importc: "mvin_wchnstr".}
-proc mvwin_wchstr*(win: PWindow, y,x: cint, wchstr: ptr cchar_t): ErrCode {.ncurses_default, importc: "mvwin_wchstr".}
-proc mvwin_wchnstr*(win: PWindow; y,x: cint, wchstr: ptr cchar_t, n: cint): ErrCode {.ncurses_default, importc: "mvwin_wchnstr".}
+proc in_wchstr*(wchstr: ptr cchar_t): ErrCode {.cdecl, importc, discardable, dynlib: libncurses.}
+proc in_wchnstr*(wchstr: ptr cchar_t, n: cint): ErrCode {.cdecl, importc, discardable, dynlib: libncurses.}
+proc win_wchstr*(win: PWindow, wchstr: ptr cchar_t): ErrCode {.cdecl, importc, discardable, dynlib: libncurses.}
+proc win_wchnstr*(win: PWindow, wchstr: ptr cchar_t, n: cint): ErrCode {.cdecl, importc, discardable, dynlib: libncurses.}
+proc mvin_wchstr*(y,x: cint, wchstr: ptr cchar_t): ErrCode {.cdecl, importc, discardable, dynlib: libncurses.}
+proc mvin_wchnstr*(y,x: cint, wchstr: ptr cchar_t, n: cint): ErrCode {.cdecl, importc, discardable, dynlib: libncurses.}
+proc mvwin_wchstr*(win: PWindow, y,x: cint, wchstr: ptr cchar_t): ErrCode {.cdecl, importc, discardable, dynlib: libncurses.}
+proc mvwin_wchnstr*(win: PWindow; y,x: cint, wchstr: ptr cchar_t, n: cint): ErrCode {.cdecl, importc, discardable, dynlib: libncurses.}
 
 #inch: get a character and attributes from a window
-proc inch*(): chtype {.ncurses_default, importc: "inch".}
-proc winch*(win: PWindow): chtype {.ncurses_default, importc: "winch".}
-proc mvinch*(y,x: cint): chtype {.ncurses_default, importc: "mvinch".}
-proc mvwinch*(win: PWindow; y,x: cint): chtype {.ncurses_default, importc: "mvwinch".}
+proc inch*(): chtype {.cdecl, importc, discardable, dynlib: libncurses.}
+proc winch*(win: PWindow): chtype {.cdecl, importc, discardable, dynlib: libncurses.}
+proc mvinch*(y,x: cint): chtype {.cdecl, importc, discardable, dynlib: libncurses.}
+proc mvwinch*(win: PWindow; y,x: cint): chtype {.cdecl, importc, discardable, dynlib: libncurses.}
 
 #inchstr: get a string of characters (and attributes) from a window
-proc inchstr*(chstr: ptr chtype): ErrCode {.ncurses_default, importc: "inchstr".}
-proc inchnstr*(chstr: ptr chtype; n: cint): ErrCode {.ncurses_default, importc: "inchnstr".}
-proc winchstr*(win: PWindow; chstr: ptr chtype): ErrCode {.ncurses_default, importc: "winchstr".}
-proc winchnstr*(win: PWindow; chstr: ptr chtype; n: cint): ErrCode {.ncurses_default, importc: "winchnstr".}
-proc mvinchstr*(y,x: cint; chstr: ptr chtype): ErrCode {.ncurses_default, importc: "mvinchstr".}
-proc mvinchnstr*(y,x: cint; chstr: ptr chtype; n: cint): ErrCode {.ncurses_default, importc: "mvinchnstr".}
-proc mvwinchstr*(win: PWindow, y,x: cint; chstr: ptr chtype): ErrCode {.ncurses_default, importc: "mvwinchstr".}
-proc mvwinchnstr*(win: PWindow, y,x: cint; chstr: ptr chtype; n: cint): ErrCode {.ncurses_default, importc: "mvwinchnstr".}
+proc inchstr*(chstr: ptr chtype): ErrCode {.cdecl, importc, discardable, dynlib: libncurses.}
+proc inchnstr*(chstr: ptr chtype; n: cint): ErrCode {.cdecl, importc, discardable, dynlib: libncurses.}
+proc winchstr*(win: PWindow; chstr: ptr chtype): ErrCode {.cdecl, importc, discardable, dynlib: libncurses.}
+proc winchnstr*(win: PWindow; chstr: ptr chtype; n: cint): ErrCode {.cdecl, importc, discardable, dynlib: libncurses.}
+proc mvinchstr*(y,x: cint; chstr: ptr chtype): ErrCode {.cdecl, importc, discardable, dynlib: libncurses.}
+proc mvinchnstr*(y,x: cint; chstr: ptr chtype; n: cint): ErrCode {.cdecl, importc, discardable, dynlib: libncurses.}
+proc mvwinchstr*(win: PWindow, y,x: cint; chstr: ptr chtype): ErrCode {.cdecl, importc, discardable, dynlib: libncurses.}
+proc mvwinchnstr*(win: PWindow, y,x: cint; chstr: ptr chtype; n: cint): ErrCode {.cdecl, importc, discardable, dynlib: libncurses.}
 
 #instr: get a string of characters from a window
-proc instr*(str: cstring): ErrCode {.ncurses_default, importc: "instr".}
-proc innstr*(str: cstring, n: cint): ErrCode {.ncurses_default, importc: "innstr".}
-proc winstr*(win: PWindow, str: cstring): ErrCode {.ncurses_default, importc: "winstr".}
-proc winnstr*(win: PWindow, str: cstring, n: cint): ErrCode {.ncurses_default, importc: "winnstr".}
-proc mvinstr*(): ErrCode {.ncurses_default, importc: "mvinstr".}
-proc mvinnstr*(): ErrCode {.ncurses_default, importc: "mvinnstr".}
-proc mvwinstr*(): ErrCode {.ncurses_default, importc: "mvwinstr".}
-proc mvwinnstr*(): ErrCode {.ncurses_default, importc: "mvwinnstr".}
+proc instr*(str: cstring): ErrCode {.cdecl, importc, discardable, dynlib: libncurses.}
+proc innstr*(str: cstring, n: cint): ErrCode {.cdecl, importc, discardable, dynlib: libncurses.}
+proc winstr*(win: PWindow, str: cstring): ErrCode {.cdecl, importc, discardable, dynlib: libncurses.}
+proc winnstr*(win: PWindow, str: cstring, n: cint): ErrCode {.cdecl, importc, discardable, dynlib: libncurses.}
+proc mvinstr*(): ErrCode {.cdecl, importc, discardable, dynlib: libncurses.}
+proc mvinnstr*(): ErrCode {.cdecl, importc, discardable, dynlib: libncurses.}
+proc mvwinstr*(): ErrCode {.cdecl, importc, discardable, dynlib: libncurses.}
+proc mvwinnstr*(): ErrCode {.cdecl, importc, discardable, dynlib: libncurses.}
 
 #inwstr: get a string of wchar_t characters from a window
-proc inwstr*(wstr: WideCString): ErrCode {.ncurses_default, importc: "inwstr".}
-proc innwstr*(wstr: WideCString; n: cint): ErrCode {.ncurses_default, importc: "innwstr".}
-proc winwstr*(win: PWindow; wstr: WideCString): ErrCode {.ncurses_default, importc: "winwstr".}
-proc winnwstr*(win: PWindow; wstr: WideCString; n: cint): ErrCode {.ncurses_default, importc: "winnwstr".}
-proc mvinwstr*(y,x: cint; wstr: WideCString): ErrCode {.ncurses_default, importc: "mvinwstr".}
-proc mvinnwstr*(y,x: cint; wstr: WideCString; n: cint): ErrCode {.ncurses_default, importc: "mvinnwstr".}
-proc mvwinwstr*(win: PWindow; y,x: cint; wstr: WideCString): ErrCode {.ncurses_default, importc: "mvwinwstr".}
-proc mvwinnwstr*(win: PWindow; y,x: cint; wstr: WideCString; n: cint): ErrCode {.ncurses_default, importc: "mvwinnwstr".}
+proc inwstr*(wstr: WideCString): ErrCode {.cdecl, importc, discardable, dynlib: libncurses.}
+proc innwstr*(wstr: WideCString; n: cint): ErrCode {.cdecl, importc, discardable, dynlib: libncurses.}
+proc winwstr*(win: PWindow; wstr: WideCString): ErrCode {.cdecl, importc, discardable, dynlib: libncurses.}
+proc winnwstr*(win: PWindow; wstr: WideCString; n: cint): ErrCode {.cdecl, importc, discardable, dynlib: libncurses.}
+proc mvinwstr*(y,x: cint; wstr: WideCString): ErrCode {.cdecl, importc, discardable, dynlib: libncurses.}
+proc mvinnwstr*(y,x: cint; wstr: WideCString; n: cint): ErrCode {.cdecl, importc, discardable, dynlib: libncurses.}
+proc mvwinwstr*(win: PWindow; y,x: cint; wstr: WideCString): ErrCode {.cdecl, importc, discardable, dynlib: libncurses.}
+proc mvwinnwstr*(win: PWindow; y,x: cint; wstr: WideCString; n: cint): ErrCode {.cdecl, importc, discardable, dynlib: libncurses.}
 
 #ins_wstr: insert a wide-character string into a window
-proc ins_wstr*(wstr: WideCString): ErrCode {.ncurses_default, importc: "ins_wstr".}
-proc ins_nwstr*(wstr: WideCString; n: cint): ErrCode {.ncurses_default, importc: "ins_nwstr".}
-proc wins_wstr*(win: PWindow; wstr: WideCString): ErrCode {.ncurses_default, importc: "wins_wstr".}
-proc wins_nwstr*(win: PWindow; wstr: WideCString; n: cint): ErrCode {.ncurses_default, importc: "wins_nwstr".}
-proc mvins_wstr*(y,x: cint; wstr: WideCString): ErrCode {.ncurses_default, importc: "mvins_wstr".}
-proc mvins_nwstr*(y,x: cint; wstr: WideCString; n: cint): ErrCode {.ncurses_default, importc: "mvins_nwstr".}
-proc mvwins_wstr*(win: PWindow; y,x: cint; wstr: WideCString): ErrCode {.ncurses_default, importc: "mvwins_wstr".}
-proc mvwins_nwstr*(win: PWindow; y,x: cint; wstr: WideCString; n: cint): ErrCode {.ncurses_default, importc: "mvwins_nwstr".}
+proc ins_wstr*(wstr: WideCString): ErrCode {.cdecl, importc, discardable, dynlib: libncurses.}
+proc ins_nwstr*(wstr: WideCString; n: cint): ErrCode {.cdecl, importc, discardable, dynlib: libncurses.}
+proc wins_wstr*(win: PWindow; wstr: WideCString): ErrCode {.cdecl, importc, discardable, dynlib: libncurses.}
+proc wins_nwstr*(win: PWindow; wstr: WideCString; n: cint): ErrCode {.cdecl, importc, discardable, dynlib: libncurses.}
+proc mvins_wstr*(y,x: cint; wstr: WideCString): ErrCode {.cdecl, importc, discardable, dynlib: libncurses.}
+proc mvins_nwstr*(y,x: cint; wstr: WideCString; n: cint): ErrCode {.cdecl, importc, discardable, dynlib: libncurses.}
+proc mvwins_wstr*(win: PWindow; y,x: cint; wstr: WideCString): ErrCode {.cdecl, importc, discardable, dynlib: libncurses.}
+proc mvwins_nwstr*(win: PWindow; y,x: cint; wstr: WideCString; n: cint): ErrCode {.cdecl, importc, discardable, dynlib: libncurses.}
 
 #ins_wch: insert a complex character and rendition into a window
-proc ins_wch*(wch: ptr cchar_t): ErrCode {.ncurses_default, importc: "ins_wch".}
-proc wins_wch*(win: PWindow; wch: ptr cchar_t): ErrCode {.ncurses_default, importc: "wins_wch".}
-proc mvins_wch*(y,x: cint; wch: ptr cchar_t): ErrCode {.ncurses_default, importc: "mvins_wch".}
-proc mvwins_wch*(win: PWindow; y,x: cint; wch: ptr cchar_t): ErrCode {.ncurses_default, importc: "mvwins_wch".}
+proc ins_wch*(wch: ptr cchar_t): ErrCode {.cdecl, importc, discardable, dynlib: libncurses.}
+proc wins_wch*(win: PWindow; wch: ptr cchar_t): ErrCode {.cdecl, importc, discardable, dynlib: libncurses.}
+proc mvins_wch*(y,x: cint; wch: ptr cchar_t): ErrCode {.cdecl, importc, discardable, dynlib: libncurses.}
+proc mvwins_wch*(win: PWindow; y,x: cint; wch: ptr cchar_t): ErrCode {.cdecl, importc, discardable, dynlib: libncurses.}
 
 #insch: insert a character before cursor in a window
-proc insch*(ch: chtype): ErrCode {.ncurses_default, importc: "insch".}
+proc insch*(ch: chtype): ErrCode {.cdecl, importc, discardable, dynlib: libncurses.}
     ## Inserts a character before the cursor in the stdscr.
     ## @Param: 'character' the character to insert.
     ## @Returns: ERR on failure and OK upon successful completion.
-proc winsch*(win: PWindow; ch: chtype): ErrCode {.ncurses_default, importc: "winsch".}
-proc mvinsch*(y,x: cint; ch: chtype): ErrCode {.ncurses_default, importc: "mvinsch".}
-proc mvwinsch*(win: PWindow; y,x: cint; ch: chtype): ErrCode {.ncurses_default, importc: "mvwinsch".}
+proc winsch*(win: PWindow; ch: chtype): ErrCode {.cdecl, importc, discardable, dynlib: libncurses.}
+proc mvinsch*(y,x: cint; ch: chtype): ErrCode {.cdecl, importc, discardable, dynlib: libncurses.}
+proc mvwinsch*(win: PWindow; y,x: cint; ch: chtype): ErrCode {.cdecl, importc, discardable, dynlib: libncurses.}
 
 #insstr: insert string before cursor in a window
-proc insstr*(str: cstring): ErrCode {.ncurses_default, importc: "insstr".}
-proc insnstr*(str: cstring; n: cint): ErrCode {.ncurses_default, importc: "insnstr".}
-proc winsstr*(win: PWindow; str: cstring): ErrCode {.ncurses_default, importc: "winsstr".}
-proc winsnstr*(win: PWindow; str: cstring; n: cint): ErrCode {.ncurses_default, importc: "winsnstr".}
-proc mvinsstr*(y,x: cint; str: cstring): ErrCode {.ncurses_default, importc: "minsstr".}
-proc mvinsnstr*(y,x: cint; str: cstring; n: cint): ErrCode {.ncurses_default, importc: "mvinsnstr".}
-proc mvwinsstr*(win: Pwindow; y,x: cint; str: cstring): ErrCode {.ncurses_default, importc: "mvwinsstr".}
-proc mvwinsnstr*(win: Pwindow; y,x: cint; str: cstring; n: cint): ErrCode {.ncurses_default, importc: "mvwinsnstr".}
+proc insstr*(str: cstring): ErrCode {.cdecl, importc, discardable, dynlib: libncurses.}
+proc insnstr*(str: cstring; n: cint): ErrCode {.cdecl, importc, discardable, dynlib: libncurses.}
+proc winsstr*(win: PWindow; str: cstring): ErrCode {.cdecl, importc, discardable, dynlib: libncurses.}
+proc winsnstr*(win: PWindow; str: cstring; n: cint): ErrCode {.cdecl, importc, discardable, dynlib: libncurses.}
+proc mvinsstr*(y,x: cint; str: cstring): ErrCode {.cdecl, importc, discardable, dynlib: libncurses.}
+proc mvinsnstr*(y,x: cint; str: cstring; n: cint): ErrCode {.cdecl, importc, discardable, dynlib: libncurses.}
+proc mvwinsstr*(win: Pwindow; y,x: cint; str: cstring): ErrCode {.cdecl, importc, discardable, dynlib: libncurses.}
+proc mvwinsnstr*(win: Pwindow; y,x: cint; str: cstring; n: cint): ErrCode {.cdecl, importc, discardable, dynlib: libncurses.}
 
 #opaque: window properties
 #https://invisible-island.net/ncurses/man/curs_opaque.3x.html
-proc is_cleared*(win: PWindow): bool {.ncurses_default, importc: "is_cleared".}
+proc is_cleared*(win: PWindow): bool {.cdecl, importc, discardable, dynlib: libncurses.}
   ## returns the value set in clearok
-proc is_idcok*(win: PWindow): bool {.ncurses_default, importc: "is_idcok".}
+proc is_idcok*(win: PWindow): bool {.cdecl, importc, discardable, dynlib: libncurses.}
   ## returns the value set in is_idcok
-proc is_idlok*(win: PWindow): bool {.ncurses_default, importc: "is_idlok".}
+proc is_idlok*(win: PWindow): bool {.cdecl, importc, discardable, dynlib: libncurses.}
   ## returns the value set in is_idlok
-proc is_immedok*(win: PWindow): bool {.ncurses_default, importc: "is_immedok".}
+proc is_immedok*(win: PWindow): bool {.cdecl, importc, discardable, dynlib: libncurses.}
   ## returns the value set in is_immedok
-proc is_keypad*(win: PWindow): bool {.ncurses_default, importc: "is_keypad".}
+proc is_keypad*(win: PWindow): bool {.cdecl, importc, discardable, dynlib: libncurses.}
   ## returns the value set in is_keypad
-proc is_leaveok*(win: PWindow): bool {.ncurses_default, importc: "is_leaveok".}
+proc is_leaveok*(win: PWindow): bool {.cdecl, importc, discardable, dynlib: libncurses.}
   ## returns the value set in is_leaveok
-proc is_nodelay*(win: PWindow): bool {.ncurses_default, importc: "is_nodelay".}
+proc is_nodelay*(win: PWindow): bool {.cdecl, importc, discardable, dynlib: libncurses.}
   ## returns the value set in is_nodelay
-proc is_notimeout*(win: PWindow): bool {.ncurses_default, importc: "is_notimeout".}
+proc is_notimeout*(win: PWindow): bool {.cdecl, importc, discardable, dynlib: libncurses.}
   ## returns the value set in is_notimeout
-proc is_pad*(win: PWindow): bool {.ncurses_default, importc: "is_pad".}
+proc is_pad*(win: PWindow): bool {.cdecl, importc, discardable, dynlib: libncurses.}
   ## returns TRUE if the window is a pad i.e., created by newpad
-proc is_scrollok*(win: PWindow): bool {.ncurses_default, importc: "is_scrollok".}
+proc is_scrollok*(win: PWindow): bool {.cdecl, importc, discardable, dynlib: libncurses.}
   ## returns the value set in is_scrollok
-proc is_subwin*(win: PWindow): bool {.ncurses_default, importc: "is_subwin".}
+proc is_subwin*(win: PWindow): bool {.cdecl, importc, discardable, dynlib: libncurses.}
   ## returns TRUE if the window is a subwindow, i.e., created by subwin
   ## or derwin
-proc is_syncok*(win: PWindow): bool {.ncurses_default, importc: "is_syncok".}
+proc is_syncok*(win: PWindow): bool {.cdecl, importc, discardable, dynlib: libncurses.}
   ## returns the value set in is_syncok
-proc wgetparent*(win: PWindow): PWindow {.ncurses_default, importc: "wgetparent".}
+proc wgetparent*(win: PWindow): PWindow {.cdecl, importc, discardable, dynlib: libncurses.}
   ## returns the parent WINDOW pointer for subwindows, or NULL for
   ## windows with no parent
-proc wgetdelay*(win: PWindow): cint {.ncurses_default, importc: "wgetdelay".}
+proc wgetdelay*(win: PWindow): cint {.cdecl, importc, discardable, dynlib: libncurses.}
   ## returns the delay timeout as set in wtimeout
-proc wgetscrreg*(win: PWindow; top, bottom: cint): cint {.ncurses_default, importc: "wgetscrreg".}
+proc wgetscrreg*(win: PWindow; top, bottom: cint): cint {.cdecl, importc, discardable, dynlib: libncurses.}
   ## returns the top and bottom rows for the scrolling margin as set in
   ## wsetscrreg
 
 #touch: refresh control routines
 #https://invisible-island.net/ncurses/man/curs_touch.3x.html
-proc touchwin*(win: PWindow): ErrCode {.ncurses_default, importc: "touchwin".}
+proc touchwin*(win: PWindow): ErrCode {.cdecl, importc, discardable, dynlib: libncurses.}
   ## Throws away all optimization information about which parts of the window
   ## have been touched, by pretending that the entire window has been drawn on.
   ## This is sometimes necessary when using overlapping windows, since a change
   ## to one window affects the other window, but the records of which lines
   ## have been changed in the other window do not reflect the change.
-proc touchline*(win: PWindow; start, count: cint): ErrCode {.ncurses_default, importc: "touchline".}
+proc touchline*(win: PWindow; start, count: cint): ErrCode {.cdecl, importc, discardable, dynlib: libncurses.}
   ## The same as touchwin, except it only pretends that count lines have been
   ## changed, beginning with line start.
-proc untouchwin*(win: PWindow): ErrCode {.ncurses_default, importc: "untouchwin".}
+proc untouchwin*(win: PWindow): ErrCode {.cdecl, importc, discardable, dynlib: libncurses.}
   ## Marks all lines in the window as unchanged since the last call to wrefresh.
-proc wtouchln*(win: PWindow; y, n, changed: cint): ErrCode {.ncurses_default, importc: "wtouchln".}
+proc wtouchln*(win: PWindow; y, n, changed: cint): ErrCode {.cdecl, importc, discardable, dynlib: libncurses.}
   ## Makes n lines in the window, starting at line y, look as if they have
   ## (changed=1) or have not (changed=0) been changed since the last call to
   ## wrefresh.
-proc is_wintouched*(win: PWindow): bool {.ncurses_default, importc: "is_wintouched".}
+proc is_wintouched*(win: PWindow): bool {.cdecl, importc, discardable, dynlib: libncurses.}
   ## Returns TRUE if the specified window was modified since the last call to
   ## wrefresh
-proc is_linetouched*(win: PWindow; line: cint): bool {.ncurses_default, importc: "is_linetouched".}
+proc is_linetouched*(win: PWindow; line: cint): bool {.cdecl, importc, discardable, dynlib: libncurses.}
   ## The same as is_wintouched, In addition, returns ERR if line is not valid
   ## for the given window.
 
 #resizeterm: change the curses terminal size
 #https://invisible-island.net/ncurses/man/resizeterm.3x.html
-proc is_term_resized*(lines, columns: cint): bool {.ncurses_default, importc: "is_term_resized".}
+proc is_term_resized*(lines, columns: cint): bool {.cdecl, importc, discardable, dynlib: libncurses.}
   ## Checks if the resize_term function would modify the window structures.
   ## returns TRUE if the windows would be modified, and FALSE otherwise.
-proc resize_term*(lines, columns: cint): ErrCode {.ncurses_default, importc: "resizeterm".}
+proc resize_term*(lines, columns: cint): ErrCode {.cdecl, importc, discardable, dynlib: libncurses.}
   ## Resizes the standard and current windows to the specified dimensions,
   ## and adjusts other bookkeeping data used by the ncurses library that
   ## record the window dimensions such as the LINES and COLS variables.
-proc resize_term_ext*(lines, columns: cint): ErrCode {.ncurses_default, importc: "resize_term".}
+proc resize_term_ext*(lines, columns: cint): ErrCode {.cdecl, discardable, dynlib: libncurses, importc: "resize_term".}
   ## Blank-fills the areas that are extended. The calling application should
   ## fill in these areas with appropriate data. The resize_term function
   ## attempts to resize all windows. However, due to the calling convention of
@@ -809,14 +808,14 @@ proc resize_term_ext*(lines, columns: cint): ErrCode {.ncurses_default, importc:
 
 #key_defined: check if a keycode is defined
 #https://invisible-island.net/ncurses/man/key_defined.3x.html
-proc key_defined*(definition: cstring): cint {.ncurses_default, importc: "key_defined".}
+proc key_defined*(definition: cstring): cint {.cdecl, importc, discardable, dynlib: libncurses.}
   ## If the string is bound to a keycode, its value (greater than zero) is
   ## returned. If no keycode is bound, zero is returned. If the string
   ## conflicts with longer strings which are bound to keys, -1 is returned.
 
 #keybound: return definition of keycode
 #https://invisible-island.net/ncurses/man/keybound.3x.html
-proc keybound*(keycode, count: cint): cstring {.ncurses_default, importc: "keybound".}
+proc keybound*(keycode, count: cint): cstring {.cdecl, importc, discardable, dynlib: libncurses.}
   ## The keycode parameter must be greater than zero, else NULL is returned.
   ## If it does not correspond to a defined key, then NULL is returned. The
   ## count parameter is used to allow the application to iterate through
@@ -825,7 +824,7 @@ proc keybound*(keycode, count: cint): cstring {.ncurses_default, importc: "keybo
 
 #keyok: enable or disable a keycode
 #https://invisible-island.net/ncurses/man/keyok.3x.html
-proc keyok(keycode: cint; enable: bool): ErrCode {.ncurses_default, importc: "keyok".}
+proc keyok(keycode: cint; enable: bool): ErrCode {.cdecl, importc, discardable, dynlib: libncurses.}
   ## The keycode must be greater than zero, else ERR is returned. If it
   ## does not correspond to a defined key, then ERR is returned. If the
   ## enable parameter is true, then the key must have been disabled, and
@@ -833,104 +832,104 @@ proc keyok(keycode: cint; enable: bool): ErrCode {.ncurses_default, importc: "ke
 
 #mcprint: ship binary data to printer
 #https://invisible-island.net/ncurses/man/curs_print.3x.html
-proc mcprint*(data: cstring; len: cint): ErrCode {.ncurses_default, importc: "mcprint".}
+proc mcprint*(data: cstring; len: cint): ErrCode {.cdecl, importc, discardable, dynlib: libncurses.}
 
 #move: move window cursor
 #https://invisible-island.net/ncurses/man/curs_move.3x.html
-proc move*(y, x: cint): ErrCode {.ncurses_default, importc: "move".}
+proc move*(y, x: cint): ErrCode {.cdecl, importc, discardable, dynlib: libncurses.}
   ## Moves the cursor of stdscr to the specified coordinates.
   ## @Param: 'y' the line to move the cursor to.
   ## @Param: 'x' the column to move the cursor to.
   ## @Returns: ERR on failure and OK upon successful completion.
-proc wmove*(win: PWindow; y,x: cint): ErrCode {.ncurses_default, importc: "wmove".}
+proc wmove*(win: PWindow; y,x: cint): ErrCode {.cdecl, importc, discardable, dynlib: libncurses.}
 
 #printw: print formatted output in windows
 #https://invisible-island.net/ncurses/man/curs_printw.3x.html
-proc printw*(fmt: cstring): ErrCode {.ncurses_default, varargs, importc: "printw".}
+proc printw*(fmt: cstring): ErrCode {.cdecl, importc, discardable, dynlib: libncurses, varargs.}
   ## Prints out a formatted string to the stdscr.
   ## @Param: 'formattedString' the string with formatting to be output to stdscr.
   ## @Returns: ERR on failure and OK upon successful completion.
-proc wprintw*(win: PWindow, fmt: cstring): ErrCode {.ncurses_default, importc: "wprintw".}
-proc mvprintw*(y, x: cint; fmt: cstring): ErrCode {.ncurses_default, varargs, importc: "mvprintw".}
+proc wprintw*(win: PWindow, fmt: cstring): ErrCode {.cdecl, importc, discardable, dynlib: libncurses.}
+proc mvprintw*(y, x: cint; fmt: cstring): ErrCode {.cdecl, importc, discardable, dynlib: libncurses, varargs.}
   ## Prints out a formatted string to the stdscr at the specified row and column.
   ## @Param: 'y' the line to move the cursor to.
   ## @Param: 'x' the column to move the cursor to.
   ## @Param: 'formattedString' the string with formatting to be output to stdscr.
   ## @Returns: ERR on failure and OK upon successful completion.
-proc mvwprintw*(win: PWindow; y,x: cint; fmt: cstring): ErrCode {.ncurses_default, varargs, importc: "mvwprintw".}
+proc mvwprintw*(win: PWindow; y,x: cint; fmt: cstring): ErrCode {.cdecl, importc, discardable, dynlib: libncurses, varargs.}
   ## Prints out a formatted string to the specified window at the specified row and column.
   ## @Param: 'destinationWindow' the window to write the string to.
   ## @Param: 'y' the line to move the cursor to.
   ## @Param: 'x' the column to move the cursor to.
   ## @Param: 'formattedString' the string with formatting to be output to stdscr.
   ## @Returns: ERR on failure and OK upon successful completion.
-proc vw_printw*(win: PWindow; fmt: cstring; varglist: varargs[cstring]): ErrCode {.ncurses_default, importc: "vw_printw"}
+proc vw_printw*(win: PWindow; fmt: cstring; varglist: varargs[cstring]): ErrCode {.cdecl, importc, discardable, dynlib: libncurses}
 
 #scanw: convert formatted input from a window
 #https://invisible-island.net/ncurses/man/curs_scanw.3x.html
-proc scanw*(fmt: cstring): ErrCode {.ncurses_default, varargs, importc: "scanw".}
+proc scanw*(fmt: cstring): ErrCode {.cdecl, importc, discardable, dynlib: libncurses, varargs.}
   ## Converts formatted input from the stdscr.
   ## @Param: 'formattedInput' Contains the fields for the input to be mapped to.
   ## @Returns: The number of fields that were mapped in the call.
-proc wscanw*(win: PWindow; fmt: cstring): ErrCode {.ncurses_default, varargs, importc: "wscanw".}
-proc mvscanw*(y,x: cint; fmt: cstring): ErrCode {.ncurses_default, varargs, importc: "mvscanw".}
-proc mvwscanw*(win: PWindow; y,x: cint; fmt: cstring): ErrCode {.ncurses_default, varargs, importc: "wscanw".}
-proc vw_scanw*(win: PWindow; fmt: cstring; varglist: varargs[cstring]): ErrCode {.ncurses_default, varargs, importc: "vw_scanw".}
+proc wscanw*(win: PWindow; fmt: cstring): ErrCode {.cdecl, importc, discardable, dynlib: libncurses, varargs.}
+proc mvscanw*(y,x: cint; fmt: cstring): ErrCode {.cdecl, importc, discardable, dynlib: libncurses, varargs.}
+proc mvwscanw*(win: PWindow; y,x: cint; fmt: cstring): ErrCode {.cdecl, importc, discardable, dynlib: libncurses, varargs.}
+proc vw_scanw*(win: PWindow; fmt: cstring; varglist: varargs[cstring]): ErrCode {.cdecl, importc, discardable, dynlib: libncurses, varargs,.}
 
 #pad: create and display pads
 #https://invisible-island.net/ncurses/man/curs_pad.3x.html
-proc newpad*(nlines, ncols: cint): PWindow {.ncurses_default, importc: "newpad".}
-proc subpad*(orig: PWindow; lines, columns, begin_y, begin_x: cint): PWindow {.ncurses_default, importc: "subpad".}
+proc newpad*(nlines, ncols: cint): PWindow {.cdecl, importc, discardable, dynlib: libncurses.}
+proc subpad*(orig: PWindow; lines, columns, begin_y, begin_x: cint): PWindow {.cdecl, importc, discardable, dynlib: libncurses.}
 proc prefresh*(pad: PWindow;
   pminrow, pmincol,
   sminrow, smincol,
   smaxrow, smaxcol: cint
-): ErrCode {.ncurses_default, importc: "prefresh".}
+): ErrCode {.cdecl, importc, discardable, dynlib: libncurses.}
 proc pnoutrefersh*(pad: PWindow;
   pminrow, pmincol,
   sminrow, smincol,
   smaxrow, smaxcol: cint
-): ErrCode {.ncurses_default, importc: "pnoutrefersh".}
-proc pechochar*(pad: PWindow; ch: chtype): ErrCode {.ncurses_default, importc: "pechochar".}
-proc pecho_wchar*(pad: PWindow; wch: WideCString): ErrCode {.ncurses_default, importc: "pecho_wchar".}
+): ErrCode {.cdecl, importc, discardable, dynlib: libncurses.}
+proc pechochar*(pad: PWindow; ch: chtype): ErrCode {.cdecl, importc, discardable, dynlib: libncurses.}
+proc pecho_wchar*(pad: PWindow; wch: WideCString): ErrCode {.cdecl, importc, discardable, dynlib: libncurses.}
 
 #scr_dump: read (write) a screen from (to) a file
 #https://invisible-island.net/ncurses/man/curs_scr_dump.3x.html
-proc scr_dump*(filename: cstring): ErrCode {.ncurses_default, importc: "scr_dump".}
-proc scr_restore*(filename: cstring): ErrCode {.ncurses_default, importc: "scr_restore".}
-proc scr_init*(filename: cstring): ErrCode {.ncurses_default, importc: "scr_init".}
-proc scr_set*(filename: cstring): ErrCode {.ncurses_default, importc: "scr_set".}
+proc scr_dump*(filename: cstring): ErrCode {.cdecl, importc, discardable, dynlib: libncurses.}
+proc scr_restore*(filename: cstring): ErrCode {.cdecl, importc, discardable, dynlib: libncurses.}
+proc scr_init*(filename: cstring): ErrCode {.cdecl, importc, discardable, dynlib: libncurses.}
+proc scr_set*(filename: cstring): ErrCode {.cdecl, importc, discardable, dynlib: libncurses.}
 
 #scroll: scroll a window
 #https://invisible-island.net/ncurses/man/curs_scroll.3x.html
-proc scroll*(win: PWindow): ErrCode {.ncurses_default, importc: "scroll".}
-proc scrl*(n: cint): ErrCode {.ncurses_default, importc: "scrl".}
-proc wscrl*(win: PWindow; n: cint): ErrCode {.ncurses_default, importc: "".}
+proc scroll*(win: PWindow): ErrCode {.cdecl, importc, discardable, dynlib: libncurses.}
+proc scrl*(n: cint): ErrCode {.cdecl, importc, discardable, dynlib: libncurses.}
+proc wscrl*(win: PWindow; n: cint): ErrCode {.cdecl, importc, discardable, dynlib: libncurses.}
 
 #termcap: direct interface to the terminfo capability database
 #https://invisible-island.net/ncurses/man/curs_termcap.3x.html
 var
-  PC {.ncurses_default, importc: "char PC".}: cchar
-  UP {.ncurses_default, importc: "char * UP".}: cstring
-  BC {.ncurses_default, importc: "char * BC".}: cstring
-  ospeed {.ncurses_default, importc: "short ospeed".}: cshort
-proc tgetent*(np, name: cstring): cint {.ncurses_default, importc: "tgetent".}
-proc tgetflag*(id: cstring): ErrCode {.ncurses_default, importc: "tgetflag".}
-proc tgetnum*(id: cstring): ErrCode {.ncurses_default, importc: "tgetnum".}
-proc tgetstr*(id: cstring; area: cstringArray ): cstring {.ncurses_default, importc: "tgetstr".}
-proc tgoto*(cap: cstring; col, row: cint): cstring {.ncurses_default, importc: "tgoto".}
-proc tputs*(str: cstring; affcnt: cint; putc: ptr proc(ch: cint): cint): ErrCode {.ncurses_default, importc: "tputs".}
+  PC {.importc.}: cchar
+  UP {.importc.}: cstring
+  BC {.importc.}: cstring
+  ospeed {.importc.}: cshort
+proc tgetent*(np, name: cstring): cint {.cdecl, importc, discardable, dynlib: libncurses.}
+proc tgetflag*(id: cstring): ErrCode {.cdecl, importc, discardable, dynlib: libncurses.}
+proc tgetnum*(id: cstring): ErrCode {.cdecl, importc, discardable, dynlib: libncurses.}
+proc tgetstr*(id: cstring; area: cstringArray ): cstring {.cdecl, importc, discardable, dynlib: libncurses.}
+proc tgoto*(cap: cstring; col, row: cint): cstring {.cdecl, importc, discardable, dynlib: libncurses.}
+proc tputs*(str: cstring; affcnt: cint; putc: ptr proc(ch: cint): cint): ErrCode {.cdecl, importc, discardable, dynlib: libncurses.}
 
 #legacy_coding: override locale-encoding checks
 #https://invisible-island.net/ncurses/man/legacy_coding.3x.html
-proc use_legacy_coding*(level: cint): cint {.ncurses_default, importc: "use_legacy_coding".}
+proc use_legacy_coding*(level: cint): cint {.cdecl, importc, discardable, dynlib: libncurses.}
   ## If  the  screen has not been initialized, or the level parameter is out
   ## of range, the function returns ERR. Otherwise, it returns the previous
   ## level: 0, 1 or 2.
 
 #wresize: resize a curses window
 #https://invisible-island.net/ncurses/man/wresize.3x.html
-proc wresize*(win: PWindow; line, column: int): ErrCode {.ncurses_default, importc: "wresize".}
+proc wresize*(win: PWindow; line, column: int): ErrCode {.cdecl, importc, discardable, dynlib: libncurses.}
 
 # mouse interface
 template NCURSES_MOUSE_MASK(b, m: untyped): untyped = ((m) shl (((b) - 1) * 5))
@@ -954,7 +953,7 @@ const
   NCURSES_DOUBLE_CLICKED*  = 0o10'i32
   NCURSES_TRIPLE_CLICKED*  = 0o20'i32
   NCURSES_RESERVED_EVENT*  = 0o40'i32
-
+  
   # event masks
   BUTTON1_RELEASED* = NCURSES_MOUSE_MASK(1, NCURSES_BUTTON_RELEASED)
   BUTTON1_PRESSED*  = NCURSES_MOUSE_MASK(1, NCURSES_BUTTON_PRESSED)

--- a/ncurses.nim
+++ b/ncurses.nim
@@ -433,10 +433,10 @@ proc define_key*(definition: cstring, keycode: cint): ErrCode {.cdecl, importc, 
 
 #terminfo: interfaces to terminfo database
 var
-  cur_term: ptr Terminal
-  boolnames, boolcodes, boolfnames: cstringArray
-  numnames, numcodes, numfnames: cstringArray
-  strnames, strcodes, strfnames: cstringArray
+  cur_term*: ptr Terminal
+  boolnames*, boolcodes*, boolfnames*: cstringArray
+  numnames*, numcodes*, numfnames*: cstringArray
+  strnames*, strcodes*, strfnames*: cstringArray
 proc setupterm*(term: cstring; filedes: cint; errret: ptr cint): ErrCode {.cdecl, importc, discardable, dynlib: libncurses.}
 proc setterm*(term: cstring): ErrCode {.cdecl, importc, discardable, dynlib: libncurses.}
 proc set_curterm*(nterm: ptr Terminal): ptr Terminal {.cdecl, importc, discardable, dynlib: libncurses.}

--- a/ncurses.nim
+++ b/ncurses.nim
@@ -19,7 +19,7 @@ type
  window* = win_st
  ldat* = object
 
- pdat_4299782170994856172* = object
+ pdat* = object
    pad_y*: cshort
    pad_x*: cshort
    pad_top*: cshort
@@ -59,7 +59,7 @@ type
    pary*: cint               # y coordinate of this window in parent
    parent*: ptr window       # pointer to parent if a sub-window
                              # these are used only if this is a pad
-   pad*: pdat_4299782170994856172
+   pad*: pdat
    yoffset*: cshort          # real begy is _begy + _yoffset
    color*: cint              # current color-pair for non-space character
 
@@ -219,6 +219,129 @@ type
    z*: cint                  # event coordinates (character-cell)
    bstate*: mmask_t          # button state bits
 
+#proc *() {.cdecl, discardable, importc: "", dynlib: libncurses.}
+
+proc add_wch*(character: chtype): cint {.cdecl, discardable, importc: "add_wch", dynlib: libncurses.}
+proc add_wchnstr*(character: chtype, numberOfCharacters: cint) {.cdecl, discardable, importc: "add_wchnstr", dynlib: libncurses.}
+proc add_wchstr*(character: chtype) {.cdecl, discardable, importc: "add_wchstr", dynlib: libncurses.}
+proc addch*(character: chtype): cint {.cdecl, discardable, importc: "addch", dynlib: libncurses.}
+    ## Puts a character into the stdscr at its current window position and then advances
+    ## the current window position to the next position.
+    ## @Param: 'character' the character to put into the current window.
+    ## @Returns: ERR on failure and OK upon successful completion.
+proc addchnstr*(character: chtype, numberOfCharacters: cint) {.cdecl, discardable, importc: "", dynlib: libncurses.}
+proc addchstr*(character: chtype) {.cdecl, discardable, importc: "", dynlib: libncurses.}
+proc addnstr*() {.cdecl, discardable, importc: "", dynlib: libncurses.}
+proc addnwstr*() {.cdecl, discardable, importc: "", dynlib: libncurses.}
+proc addstr*(stringToAdd: cstring): cint {.cdecl, discardable, importc: "addstr", dynlib: libncurses.}
+    ## Adds a string of characters the the stdscr and advances the cursor.
+    ## @Param: The string to add the stdscr.
+    ## @Returns: ERR on failure and OK upon successful completion.
+proc addwstr*() {.cdecl, discardable, importc: "", dynlib: libncurses.}
+proc alloc_pair*() {.cdecl, discardable, importc: "", dynlib: libncurses.}
+proc assume_default_colors*() {.cdecl, discardable, importc: "", dynlib: libncurses.}
+proc attr_get*() {.cdecl, discardable, importc: "", dynlib: libncurses.}
+proc attr_off*() {.cdecl, discardable, importc: "", dynlib: libncurses.}
+proc attr_on*() {.cdecl, discardable, importc: "", dynlib: libncurses.}
+proc attr_set*() {.cdecl, discardable, importc: "", dynlib: libncurses.}
+proc attroff*(attributes: int64): cint {.cdecl, discardable, importc: "attroff", dynlib: libncurses.}
+    ## Turns off the named attributes without affecting any other attributes.
+    ## @Param: 'attributes' the attributes to turn off for the current window.
+    ## @Returns: An integer value, but the returned value does not have any meaning and can
+    ## thus be ignored.
+proc attron*(attributes: int64): cint {.cdecl, discardable, importc: "attron", dynlib: libncurses.}
+    ## Turns on the named attributes without affecting any other attributes.
+    ## @Param: 'attributes' the attributes to turn on for the current window.
+    ## @Returns: An integer value, but the returned value does not have any meaning and can
+    ## thus be ignored.
+proc attrset*(attributes: int64): cint {.cdecl, discardable, importc: "attrset", dynlib: libncurses.}
+    ## Sets the current attributes of the given window to the provided attributes.
+    ## @Param: 'attributes', the attributes to apply to the current window.
+    ## @Returns: An integer value, but the returned value does not have any meaning and can
+    ## thus be ignored.
+proc baudrate*() {.cdecl, discardable, importc: "", dynlib: libncurses.}
+proc beep*(): cint {.cdecl, discardable, importc: "beep", dynlib: libncurses.}
+    ## Sounds an audible alarm on the terminal, otherwise it flashes the screen (visible bell).
+    ## @Returns: ERR on failure and OK upon successfully beeping.
+proc bkgd*(background: int64): cint {.cdecl, discardable, importc: "bkgd", dynlib: libncurses.}
+    ## Sets the background property of the current window and apply this setting to every
+    ## character position in the window.
+    ## @Param: 'background' the background property to apply.
+proc bkgdset*() {.cdecl, discardable, importc: "", dynlib: libncurses.}
+proc bkgrnd*() {.cdecl, discardable, importc: "", dynlib: libncurses.}
+proc bkgrndset*() {.cdecl, discardable, importc: "", dynlib: libncurses.}
+proc border*() {.cdecl, discardable, importc: "", dynlib: libncurses.}
+proc border_set*() {.cdecl, discardable, importc: "", dynlib: libncurses.}
+proc box*(a2: ptr window, x, y: int64): cint {.cdecl, discardable, importc: "box", dynlib: libncurses.}
+proc box_set*() {.cdecl, discardable, importc: "", dynlib: libncurses.}
+proc can_change_color*(): bool {.cdecl, importc: "can_change_color", dynlib: libncurses.}
+    ## Used to determine if the terminal supports colours and can change their definitions.
+    ## @Returns: true if the terminal supports colours and can change their definitions or
+    ## false otherwise.
+proc cbreak*(): cint {.cdecl, discardable, importc: "cbreak", dynlib: libncurses.}
+    ## The cbreak routine disables line buffering and erase/kill character-processing
+    ## (interrupt and flow control characters are unaffected), making characters typed by
+    ## the user immediately available to the program.
+    ## @Returns: ERR on failure and OK upon successful completion.
+proc chgat*() {.cdecl, discardable, importc: "", dynlib: libncurses.}
+proc clear*(): cint {.cdecl, discardable, importc: "clear", dynlib: libncurses.}
+proc clearok*() {.cdecl, discardable, importc: "", dynlib: libncurses.}
+proc clrtobot*() {.cdecl, discardable, importc: "", dynlib: libncurses.}
+proc clrtoeol*() {.cdecl, discardable, importc: "", dynlib: libncurses.}
+proc color_content*() {.cdecl, discardable, importc: "", dynlib: libncurses.}
+proc color_set*() {.cdecl, discardable, importc: "", dynlib: libncurses.}
+proc copywin*() {.cdecl, discardable, importc: "", dynlib: libncurses.}
+proc copy*() {.cdecl, discardable, importc: "", dynlib: libncurses.}
+proc curs_set*(visibility: int): cint {.cdecl, discardable, importc: "curs_set", dynlib: libncurses.}
+proc curses_version*() {.cdecl, discardable, importc: "", dynlib: libncurses.}
+proc def_prog_mode*(): cint {.cdecl, discardable, importc: "def_prog_mode", dynlib: libncurses.}
+proc def_shell_mode*() {.cdecl, discardable, importc: "", dynlib: libncurses.}
+proc define_key*() {.cdecl, discardable, importc: "", dynlib: libncurses.}
+proc del_curterm*() {.cdecl, discardable, importc: "", dynlib: libncurses.}
+proc delay_output*() {.cdecl, discardable, importc: "", dynlib: libncurses.}
+proc delch*(): cint {.cdecl, discardable, importc: "delch", dynlib: libncurses.}
+    ## Delete the character under the cursor in the stdscr.
+    ## @Returns: ERR on failure and OK upon successfully flashing.
+proc deleteln*(): cint {.cdecl, discardable, importc: "deleteln", dynlib: libncurses.}
+    ## Deletes the line under the cursor in the stdscr. All lines below the current line are moved up one line.
+    ## The bottom line of the window is cleared and the cursor position does not change.
+    ## @Returns: ERR on failure and OK upon successful completion.
+proc delscreen*() {.cdecl, discardable, importc: "", dynlib: libncurses.}
+proc delwin*(win: ptr window): cint {.cdecl, discardable, importc: "delwin", dynlib: libncurses.}
+proc derwin*() {.cdecl, discardable, importc: "", dynlib: libncurses.}
+proc doupdate*() {.cdecl, discardable, importc: "", dynlib: libncurses.}
+proc dupwin*() {.cdecl, discardable, importc: "", dynlib: libncurses.}
+proc echo*() {.cdecl, discardable, importc: "", dynlib: libncurses.}
+proc echo_whchar*() {.cdecl, discardable, importc: "", dynlib: libncurses.}
+proc echochar*() {.cdecl, discardable, importc: "", dynlib: libncurses.}
+proc endwin*(): cint {.cdecl, discardable, importc: "endwin", dynlib: libncurses.}
+    ## A program should always call endwin before exiting or escaping from curses mode temporarily. This routine
+    ## restores tty modes, moves the cursor to the lower left-hand corner of the screen and resets the terminal into the
+    ## proper non-visual mode. Calling refresh or doupdate after a temporary escape causes the program to resume visual mode.
+    ## @Returns: ERR on failure and OK upon successful completion.
+proc erase*(): cint {.cdecl, discardable, importc: "erase", dynlib: libncurses.}
+proc erasechar*() {.cdecl, discardable, importc: "", dynlib: libncurses.}
+proc erasewchar*() {.cdecl, discardable, importc: "", dynlib: libncurses.}
+proc extended_color_content*() {.cdecl, discardable, importc: "", dynlib: libncurses.}
+proc extended_pair_content*() {.cdecl, discardable, importc: "", dynlib: libncurses.}
+proc extended_slk_color*() {.cdecl, discardable, importc: "", dynlib: libncurses.}
+proc filter*() {.cdecl, discardable, importc: "", dynlib: libncurses.}
+proc find_pair*() {.cdecl, discardable, importc: "", dynlib: libncurses.}
+proc flash*() {.cdecl, discardable, importc: "", dynlib: libncurses.}
+proc flushinp*() {.cdecl, discardable, importc: "", dynlib: libncurses.}
+proc free_pair*() {.cdecl, discardable, importc: "", dynlib: libncurses.}
+proc get_wch*() {.cdecl, discardable, importc: "", dynlib: libncurses.}
+proc get_wstr*() {.cdecl, discardable, importc: "", dynlib: libncurses.}
+proc getattrs*(a2: ptr window): cint {.cdecl, discardable, importc: "getattrs", dynlib: libncurses.}
+proc getbegx*(a2: ptr window): cint {.cdecl, discardable, importc: "getbegx", dynlib: libncurses.}
+proc getbegy*(a2: ptr window): cint {.cdecl, discardable, importc: "getbegy", dynlib: libncurses.}
+proc getcurx*(a2: ptr window): cint {.cdecl, discardable, importc: "getcurx", dynlib: libncurses.}
+proc getcury*(a2: ptr window): cint {.cdecl, discardable, importc: "getcury", dynlib: libncurses.}
+proc getmaxx*(a2: ptr window): cint {.cdecl, discardable, importc: "getmaxx", dynlib: libncurses.}
+proc getmaxy*(a2: ptr window): cint {.cdecl, discardable, importc: "getmaxy", dynlib: libncurses.}
+proc getparx*(a2: ptr window): cint {.cdecl, discardable, importc: "getparx", dynlib: libncurses.}
+proc getpary*(a2: ptr window): cint {.cdecl, discardable, importc: "getpary", dynlib: libncurses.}
+proc *() {.cdecl, discardable, importc: "", dynlib: libncurses.}
 
 proc has_mouse*(): bool {.cdecl, importc: "has_mouse", dynlib: libncurses.}
 proc getmouse*(a2: ptr MEVENT): cint {.cdecl, importc: "getmouse", dynlib: libncurses.}
@@ -229,23 +352,11 @@ proc mouseinterval*(a2: cint): cint {.cdecl, importc: "mouseinterval", dynlib: l
 proc wmouse_trafo*(a2: ptr window; a3: ptr cint; a4: ptr cint; a5: bool): bool {.cdecl, importc: "wmouse_trafo", dynlib: libncurses.}
 proc mouse_trafo*(a2: ptr cint; a3: ptr cint; a4: bool): bool {.cdecl, importc: "mouse_trafo", dynlib: libncurses.}
 
-#
-#  These functions are not in X/Open, but we use them in macro definitions:
-#
+# These functions are not in X/Open, but we use them in macro definitions:
 
-proc getattrs*(a2: ptr window): cint {.cdecl, discardable, importc: "getattrs", dynlib: libncurses.}
-proc getcurx*(a2: ptr window): cint {.cdecl, discardable, importc: "getcurx", dynlib: libncurses.}
-proc getcury*(a2: ptr window): cint {.cdecl, discardable, importc: "getcury", dynlib: libncurses.}
-proc getbegx*(a2: ptr window): cint {.cdecl, discardable, importc: "getbegx", dynlib: libncurses.}
-proc getbegy*(a2: ptr window): cint {.cdecl, discardable, importc: "getbegy", dynlib: libncurses.}
-proc getmaxx*(a2: ptr window): cint {.cdecl, discardable, importc: "getmaxx", dynlib: libncurses.}
-proc getmaxy*(a2: ptr window): cint {.cdecl, discardable, importc: "getmaxy", dynlib: libncurses.}
-proc getparx*(a2: ptr window): cint {.cdecl, discardable, importc: "getparx", dynlib: libncurses.}
-proc getpary*(a2: ptr window): cint {.cdecl, discardable, importc: "getpary", dynlib: libncurses.}
+
 
 proc newwin*(lines, columns, begin_y, begin_x: int): ptr window {.cdecl, discardable, importc: "newwin", dynlib: libncurses.}
-
-proc delwin*(win: ptr window): cint {.cdecl, discardable, importc: "delwin", dynlib: libncurses.}
 
 proc mvwin*(win: ptr window, y, x: int): cint {.cdecl, discardable, importc: "mvwin", dynlib: libncurses.}
 
@@ -258,8 +369,6 @@ proc keypad*(win: ptr window, bf: bool): cint {.cdecl, discardable, importc: "ke
 proc scrollok*(win: ptr window, bf: bool): cint {.cdecl, discardable, importc: "scrollok", dynlib: libncurses.}
 
 proc scroll*(win: ptr window): cint {.cdecl, discardable, importc: "scroll", dynlib: libncurses.}
-
-proc erase*(): cint {.cdecl, discardable, importc: "erase", dynlib: libncurses.}
 
 proc werase*(win: ptr window): cint {.cdecl, discardable, importc: "werase", dynlib: libncurses.}
 
@@ -285,11 +394,7 @@ proc mvwaddstr*(win: ptr window, y, x: int, str: cstring): cint {.cdecl, discard
 
 proc set_escdelay*(size: int): cint {.cdecl, discardable, importc: "set_escdelay", dynlib: libncurses.}
 
-proc def_prog_mode*(): cint {.cdecl, discardable, importc: "def_prog_mode", dynlib: libncurses.}
-
 proc reset_prog_mode*(): cint {.cdecl, discardable, importc: "reset_prog_mode", dynlib: libncurses.}
-
-proc box*(a2: ptr window, x, y: int64): cint {.cdecl, discardable, importc: "box", dynlib: libncurses.}
 
 proc raw*(): cint {.cdecl, discardable, importc: "raw", dynlib: libncurses.}
 
@@ -302,74 +407,6 @@ proc noecho*(): cint {.cdecl, discardable, importc: "noecho", dynlib: libncurses
 proc onecho*(): cint {.cdecl, discardable, importc: "echo", dynlib: libncurses.}
 
 proc use_default_colors*(): cint {.cdecl, discardable, importc: "use_default_colors", dynlib: libncurses.}
-
-proc curs_set*(visibility: int): cint {.cdecl, discardable, importc: "curs_set", dynlib: libncurses.}
-
-proc clear*(): cint {.cdecl, discardable, importc: "clear", dynlib: libncurses.}
-
-proc addch*(character: chtype): cint {.cdecl, discardable, importc: "addch", dynlib: libncurses.}
-    ## Puts a character into the stdscr at its current window position and then advances
-    ## the current window position to the next position.
-    ## @Param: 'character' the character to put into the current window.
-    ## @Returns: ERR on failure and OK upon successful completion.
-
-proc addstr*(stringToAdd: cstring): cint {.cdecl, discardable, importc: "addstr", dynlib: libncurses.}
-    ## Adds a string of characters the the stdscr and advances the cursor.
-    ## @Param: The string to add the stdscr.
-    ## @Returns: ERR on failure and OK upon successful completion.
-
-proc attroff*(attributes: int64): cint {.cdecl, discardable, importc: "attroff", dynlib: libncurses.}
-    ## Turns off the named attributes without affecting any other attributes.
-    ## @Param: 'attributes' the attributes to turn off for the current window.
-    ## @Returns: An integer value, but the returned value does not have any meaning and can
-    ## thus be ignored.
-
-proc attron*(attributes: int64): cint {.cdecl, discardable, importc: "attron", dynlib: libncurses.}
-    ## Turns on the named attributes without affecting any other attributes.
-    ## @Param: 'attributes' the attributes to turn on for the current window.
-    ## @Returns: An integer value, but the returned value does not have any meaning and can
-    ## thus be ignored.
-
-proc attrset*(attributes: int64): cint {.cdecl, discardable, importc: "attrset", dynlib: libncurses.}
-    ## Sets the current attributes of the given window to the provided attributes.
-    ## @Param: 'attributes', the attributes to apply to the current window.
-    ## @Returns: An integer value, but the returned value does not have any meaning and can
-    ## thus be ignored.
-
-proc beep*(): cint {.cdecl, discardable, importc: "beep", dynlib: libncurses.}
-    ## Sounds an audible alarm on the terminal, otherwise it flashes the screen (visible bell).
-    ## @Returns: ERR on failure and OK upon successfully beeping.
-
-proc bkgd*(background: int64): cint {.cdecl, discardable, importc: "bkgd", dynlib: libncurses.}
-    ## Sets the background property of the current window and apply this setting to every
-    ## character position in the window.
-    ## @Param: 'background' the background property to apply.
-
-proc can_change_color*(): bool {.cdecl, importc: "can_change_color", dynlib: libncurses.}
-    ## Used to determine if the terminal supports colours and can change their definitions.
-    ## @Returns: true if the terminal supports colours and can change their definitions or
-    ## false otherwise.
-
-proc cbreak*(): cint {.cdecl, discardable, importc: "cbreak", dynlib: libncurses.}
-    ## The cbreak routine disables line buffering and erase/kill character-processing
-    ## (interrupt and flow control characters are unaffected), making characters typed by
-    ## the user immediately available to the program.
-    ## @Returns: ERR on failure and OK upon successful completion.
-
-proc delch*(): cint {.cdecl, discardable, importc: "delch", dynlib: libncurses.}
-    ## Delete the character under the cursor in the stdscr.
-    ## @Returns: ERR on failure and OK upon successfully flashing.
-
-proc deleteln*(): cint {.cdecl, discardable, importc: "deleteln", dynlib: libncurses.}
-    ## Deletes the line under the cursor in the stdscr. All lines below the current line are moved up one line.
-    ## The bottom line of the window is cleared and the cursor position does not change.
-    ## @Returns: ERR on failure and OK upon successful completion.
-
-proc endwin*(): cint {.cdecl, discardable, importc: "endwin", dynlib: libncurses.}
-    ## A program should always call endwin before exiting or escaping from curses mode temporarily. This routine
-    ## restores tty modes, moves the cursor to the lower left-hand corner of the screen and resets the terminal into the
-    ## proper non-visual mode. Calling refresh or doupdate after a temporary escape causes the program to resume visual mode.
-    ## @Returns: ERR on failure and OK upon successful completion.
 
 proc flash*(): cint {.cdecl, discardable, importc: "flash", dynlib: libncurses.}
     ## Flashes the screen and if that is not possible it sounds the alert. If this is not possible
@@ -498,14 +535,6 @@ proc wgetch*(sourceWindow: ptr window): cint {.cdecl, discardable, importc: "wge
     ## Read a character from the specified window.
     ## @Param: 'sourceWindow' the window to read a character from.
     ## @Returns: ERR on failure and OK upon successful completion.
-
-proc getmaxyx*(win: ptr window, y, x: var int) =
-    ## retrieves the size of the specified window in the provided y and x parameters.
-    ## @Param: 'win' the window to measure.
-    ## @Param: 'y' stores the height of the window.
-    ## @Param: 'x' stores the width of the window.
-    y = getmaxy(win)
-    x = getmaxx(win)
 
 proc getyx*(win: ptr window, y, x: var int) =
     ## Reads the logical cursor location from the specified window.

--- a/ncurses.nim
+++ b/ncurses.nim
@@ -70,7 +70,7 @@ type
     bstate*: mmask_t         # button state bits
   
   #not ncurses but used to make things easier
-  ErrCode* = distinct cint ## Returns ERR upon failure or OK on success.
+  ErrCode* = distinct cint ## Error Code. Returns ERR (-1) upon failure or OK (0) on success.
   PWindow* = ptr Window
   PScreen* = ptr Screen
 
@@ -101,7 +101,7 @@ var
     ## terminal can support.
 template COLOR_PAIR*(n: untyped): untyped = NCURSES_BITS((n), 0'i64)
 template PAIR_NUMBER*(a: untyped): untyped =
-  (NCURSES_CAST(int, ((NCURSES_CAST(cuint, (a)) and A_COLOR) shr
+  (NCURSES_CAST(cint, ((NCURSES_CAST(cuint, (a)) and A_COLOR) shr
     NCURSES_ATTR_SHIFT)))
 
 proc start_color*(): ErrCode {.cdecl, importc, discardable, dynlib: libncurses.}
@@ -297,7 +297,7 @@ proc erasewchar*(ch: WideCString) {.cdecl, importc, discardable, dynlib: libncur
 proc has_ic*(): bool {.cdecl, importc, discardable, dynlib: libncurses.}
 proc has_il*(): bool {.cdecl, importc, discardable, dynlib: libncurses.}
 proc killchar*(): cchar {.cdecl, importc, discardable, dynlib: libncurses.}
-proc killwchar*(ch: WideCString): char {.cdecl, importc, discardable, dynlib: libncurses.}
+proc killwchar*(ch: WideCString): cchar {.cdecl, importc, discardable, dynlib: libncurses.}
 proc longname*(): cstring {.cdecl, importc, discardable, dynlib: libncurses.}
 proc term_attrs*(): attr_t {.cdecl, importc, discardable, dynlib: libncurses.}
 proc term_attrs_ch*(): chtype {.cdecl, importc: "termattrs", discardable, dynlib: libncurses.} ## Previously termattrs

--- a/ncurses.nim
+++ b/ncurses.nim
@@ -7,59 +7,57 @@ else:
   const libncurses* = "libncursesw.so"
 
 type
-  # 32 or 64
   chtype*  = cuint ## Holds a character and possibly an attribute
-  # ...must be at least as wide as chtype
-  attr_t*  = chtype ## Attribute
+  attr_t*  = chtype ## Attribute type
 
-  cchar_t* = object #E complex char
+  cchar_t* = object ## Complex char
     attr: attr_t
     chars: WideCString #5
     ext_color: cint
 
-  ldat = object ## line data
+  ldat = object ## Holds line data
   Screen* = object
   Terminal* = object
-  Window* = object ## window struct
-    cury*, curx*: cshort      # current cursor position
+  Window* = object ## Holds window data
+    cury, curx: cshort       # current cursor position
     
     # window location and size
-    maxy*, maxx*: cshort      # maximums of x and y, NOT window size
-    begy*, begx*: cshort      # screen coords of upper-left-hand corner
-    flags*: cshort            # window state flags
+    maxy, maxx: cshort       # maximums of x and y, NOT window size
+    begy, begx: cshort       # screen coords of upper-left-hand corner
+    flags: cshort            # window state flags
     
     # attribute tracking
-    attrs*: attr_t            # current attribute for non-space character
-    bkgd*: chtype             # current background char/attribute pair
+    attrs: attr_t            # current attribute for non-space character
+    bkgd: chtype             # current background char/attribute pair
     
     # option values set by user
-    notimeout*: bool          # no time out on function-key entry?
-    clear*: bool              # consider all data in the window invalid?
-    leaveok*: bool            # OK to not reset cursor on exit?
-    scroll*: bool             # OK to scroll this window?
-    idlok*: bool              # OK to use insert/delete line?
-    idcok*: bool              # OK to use insert/delete char?
-    immed*: bool              # window in immed mode? (not yet used)
-    sync*: bool               # window in sync mode?
-    use_keypad*: bool         # process function keys into KEY_ symbols?
-    delay*: cint              # 0 = nodelay, <0 = blocking, >0 = delay
+    notimeout: bool          # no time out on function-key entry?
+    clear: bool              # consider all data in the window invalid?
+    leaveok: bool            # OK to not reset cursor on exit?
+    scroll: bool             # OK to scroll this window?
+    idlok: bool              # OK to use insert/delete line?
+    idcok: bool              # OK to use insert/delete char?
+    immed: bool              # window in immed mode? (not yet used)
+    sync: bool               # window in sync mode?
+    use_keypad: bool         # process function keys into KEY_ symbols?
+    delay: cint              # 0 = nodelay, <0 = blocking, >0 = delay
     
-    line*: ptr ldat           # the actual line data
+    line: ptr ldat           # the actual line data
     
     # global screen state
-    regtop*: cshort           # top line of scrolling region
-    regbottom*: cshort        # bottom line of scrolling region
+    regtop: cshort           # top line of scrolling region
+    regbottom: cshort        # bottom line of scrolling region
     
     # these are used only if this is a sub-window
-    pary*, parx*: cint        # y, x coordinates of this window in parent
-    parent*: PWindow       # pointer to parent if a sub-window
+    pary, parx: cint         # y, x coordinates of this window in parent
+    parent: PWindow          # pointer to parent if a sub-window
     
     # these are used only if this is a pad
-    pad*: pdat
-    yoffset*: cshort          # real begy is _begy + _yoffset
-    bkgrnd*: cchar_t          # current background char/attribute pair
-    color*: cint              # current color-pair for non-space character
-  
+    pad: pdat
+    yoffset: cshort          # real begy is _begy + _yoffset
+    bkgrnd: cchar_t          # current background char/attribute pair
+    color: cint              # current color-pair for non-space character
+
   pdat = object ## pad data
     pad_y*,      pad_x*:     cshort
     pad_top*,    pad_left*:  cshort
@@ -67,9 +65,9 @@ type
 
   mmask_t* = uint32
   Mevent* = object ## mouse event
-    id*: cshort               # ID to distinguish multiple devices
-    x*, y*, z*: cint          # event coordinates (character-cell)
-    bstate*: mmask_t          # button state bits
+    id*: cshort              # ID to distinguish multiple devices
+    x*, y*, z*: cint         # event coordinates (character-cell)
+    bstate*: mmask_t         # button state bits
   
   #not ncurses but used to make things easier
   ErrCode* = distinct cint ## Returns ERR upon failure or OK on success.
@@ -85,7 +83,6 @@ template NCURSES_BITS(mask, shift: untyped): untyped =
   (NCURSES_CAST(chtype, (mask)) shl ((shift) + NCURSES_ATTR_SHIFT))
 
 #color: color manipulation routines
-#https://invisible-island.net/ncurses/man/curs_color.3x.html
 const
   COLOR_BLACK*   = 0
   COLOR_RED*     = 1
@@ -97,10 +94,10 @@ const
   COLOR_WHITE*   = 7
 var
   COLORS* {.importc: "COLORS", dynlib: libncurses.}: cint
-    ## is initialized by start_color to the maximum number of colors thfe
+    ## Initialized by start_color to the maximum number of colors thfe
     ## terminal can support.
   COLOR_PAIRS* {.importc: "COLOR_PAIRS", dynlib: libncurses.}: cint
-    ## is initialized by start_color to the maximum number of color pairs the
+    ## Initialized by start_color to the maximum number of color pairs the
     ## terminal can support.
 template COLOR_PAIR*(n: untyped): untyped = NCURSES_BITS((n), 0'i64)
 template PAIR_NUMBER*(a: untyped): untyped =
@@ -148,7 +145,7 @@ proc wadd_wch*(win: PWindow, wch: ptr cchar_t): ErrCode {.cdecl, importc, discar
 proc mvadd_wch*(y, x: cint, wch: ptr cchar_t): ErrCode {.cdecl, importc, discardable, dynlib: libncurses.}
 proc mvwadd_wch*(win: PWindow, y, x: cint, wch: ptr cchar_t): ErrCode {.cdecl, importc, discardable, dynlib: libncurses.}
 proc echo_wchar*(wch: ptr cchar_t): ErrCode {.cdecl, importc, discardable, dynlib: libncurses.}
-proc wech_wchar*(win: PWindow, wch: ptr cchar_t): ErrCode {.cdecl, importc, discardable, dynlib: libncurses.}
+proc wecho_wchar*(win: PWindow, wch: ptr cchar_t): ErrCode {.cdecl, importc, discardable, dynlib: libncurses.}
 
 #add_wchstr: Adding an array of complex characters to a window
 proc add_wchstr*(wchstr: ptr cchar_t): ErrCode {.cdecl, importc, discardable, dynlib: libncurses.}
@@ -211,7 +208,8 @@ proc mvaddnstr*(y, x: cint, str: cstring, n: cint): ErrCode {.cdecl, importc, di
 proc mvwaddstr*(win: PWindow, y, x: cint, str: cstring): ErrCode {.cdecl, importc, discardable, dynlib: libncurses.}
 proc mvwaddnstr*(win: PWindow, y, x: cint, str: cstring, n: cint): ErrCode {.cdecl, importc, discardable, dynlib: libncurses.}
 
-#addwstr: Adding a string of wide characters to a window (WideCString)
+#addwstr: Adding a string of wide characters to a window (WideCString) ## Not used?
+#[
 proc addwstr(wstr: WideCString): ErrCode {.cdecl, importc, discardable, dynlib: libncurses.}
 proc addnwstr(wstr: WideCString, n: cint): ErrCode {.cdecl, importc, discardable, dynlib: libncurses.}
 proc waddwstr(win: PWindow, wstr: WideCString): ErrCode {.cdecl, importc, discardable, dynlib: libncurses.}
@@ -220,6 +218,7 @@ proc mvaddwstr(y, x: cint, win: PWindow, wstr: WideCString): ErrCode {.cdecl, im
 proc mvaddnwstr(y, x: cint, win: PWindow, wstr: WideCString, n: cint): ErrCode {.cdecl, importc, discardable, dynlib: libncurses.}
 proc mvwaddwstr(win: PWindow, y, x: cint, wstr: WideCString): ErrCode {.cdecl, importc, discardable, dynlib: libncurses.}
 proc mvwaddnwstr(win: PWindow, y, x: cint, wstr: WideCString, n: cint): ErrCode {.cdecl, importc, discardable, dynlib: libncurses.}
+]#
 
 #new_pair: Color-pair functions
 proc alloc_pair*(fg, bg: cint): ErrCode {.cdecl, importc, discardable, dynlib: libncurses.}
@@ -237,8 +236,8 @@ const
   A_ATTRIBUTES*  = NCURSES_BITS(not (u1 - u1),  0)
   A_CHAR_TEXT*   = (NCURSES_BITS(u1, 0) - u1.chtype)
   A_COLOR*       = NCURSES_BITS((u1 shl 8) - u1, 0)
-  A_STANDOUT*    = NCURSES_BITS(u1, 8)
-  A_UNDERLINE*   = NCURSES_BITS(u1, 9)
+  A_STANDOUT*    = NCURSES_BITS(u1,  8)
+  A_UNDERLINE*   = NCURSES_BITS(u1,  9)
   A_REVERSE*     = NCURSES_BITS(u1, 10)
   A_BLINK*       = NCURSES_BITS(u1, 11)
   A_DIM*         = NCURSES_BITS(u1, 12)
@@ -286,7 +285,7 @@ proc mvchgat*(y, x: cint, n: cint, attr: attr_t, pair: cshort, opts: pointer): E
 proc mvwchgat*(win: PWindow, y, x: cint, n: cint, attr: attr_t, pair: cshort, opts: pointer): ErrCode {.cdecl, importc, discardable, dynlib: libncurses.}
 proc color_set*(pair: cshort, opts: pointer): ErrCode {.cdecl, importc, discardable, dynlib: libncurses.}
 proc wcolor_set*(win: PWindow, pair: cshort, opts: pointer): ErrCode {.cdecl, importc, discardable, dynlib: libncurses.}
-proc standend(): ErrCode {.cdecl, importc, discardable, dynlib: libncurses.}
+#proc standend(): ErrCode {.cdecl, importc, discardable, dynlib: libncurses.} ## Not used?
 proc wstandend*(win: PWindow): ErrCode {.cdecl, importc, discardable, dynlib: libncurses.}
 proc standout*(): ErrCode {.cdecl, importc, discardable, dynlib: libncurses.}
 proc wstandout*(win: PWindow): ErrCode {.cdecl, importc, discardable, dynlib: libncurses.}
@@ -422,9 +421,9 @@ proc setsyx*(y,x: cint): void {.cdecl, importc, discardable, dynlib: libncurses.
 proc ripoffline*(line: cint, init: proc(win: PWindow, cols: cint): cint): ErrCode {.cdecl, importc, discardable, dynlib: libncurses.}
 proc curs_set*(visibility: cint): cint {.cdecl, importc, discardable, dynlib: libncurses.}
 proc napms*(ms: cint): cint {.cdecl, importc, discardable, dynlib: libncurses.}
-    ## Used to sleep for the specified milliseconds.
-    ## @Params: 'milliseconds' the number of milliseconds to sleep for.
-    ## @Returns: ERR on failure and OK upon successful completion.
+  ## Used to sleep for the specified milliseconds.
+  ## @Params: 'milliseconds' the number of milliseconds to sleep for.
+  ## @Returns: ERR on failure and OK upon successful completion.
 
 #extend: misc extensions
 proc curses_version*(): cstring {.cdecl, importc, discardable, dynlib: libncurses.}
@@ -712,9 +711,9 @@ proc mvwins_wch*(win: PWindow; y,x: cint; wch: ptr cchar_t): ErrCode {.cdecl, im
 
 #insch: insert a character before cursor in a window
 proc insch*(ch: chtype): ErrCode {.cdecl, importc, discardable, dynlib: libncurses.}
-    ## Inserts a character before the cursor in the stdscr.
-    ## @Param: 'character' the character to insert.
-    ## @Returns: ERR on failure and OK upon successful completion.
+  ## Inserts a character before the cursor in the stdscr.
+  ## @Param: 'character' the character to insert.
+  ## @Returns: ERR on failure and OK upon successful completion.
 proc winsch*(win: PWindow; ch: chtype): ErrCode {.cdecl, importc, discardable, dynlib: libncurses.}
 proc mvinsch*(y,x: cint; ch: chtype): ErrCode {.cdecl, importc, discardable, dynlib: libncurses.}
 proc mvwinsch*(win: PWindow; y,x: cint; ch: chtype): ErrCode {.cdecl, importc, discardable, dynlib: libncurses.}
@@ -730,7 +729,6 @@ proc mvwinsstr*(win: Pwindow; y,x: cint; str: cstring): ErrCode {.cdecl, importc
 proc mvwinsnstr*(win: Pwindow; y,x: cint; str: cstring; n: cint): ErrCode {.cdecl, importc, discardable, dynlib: libncurses.}
 
 #opaque: window properties
-#https://invisible-island.net/ncurses/man/curs_opaque.3x.html
 proc is_cleared*(win: PWindow): bool {.cdecl, importc, discardable, dynlib: libncurses.}
   ## returns the value set in clearok
 proc is_idcok*(win: PWindow): bool {.cdecl, importc, discardable, dynlib: libncurses.}
@@ -766,7 +764,6 @@ proc wgetscrreg*(win: PWindow; top, bottom: cint): cint {.cdecl, importc, discar
   ## wsetscrreg
 
 #touch: refresh control routines
-#https://invisible-island.net/ncurses/man/curs_touch.3x.html
 proc touchwin*(win: PWindow): ErrCode {.cdecl, importc, discardable, dynlib: libncurses.}
   ## Throws away all optimization information about which parts of the window
   ## have been touched, by pretending that the entire window has been drawn on.
@@ -790,7 +787,6 @@ proc is_linetouched*(win: PWindow; line: cint): bool {.cdecl, importc, discardab
   ## for the given window.
 
 #resizeterm: change the curses terminal size
-#https://invisible-island.net/ncurses/man/resizeterm.3x.html
 proc is_term_resized*(lines, columns: cint): bool {.cdecl, importc, discardable, dynlib: libncurses.}
   ## Checks if the resize_term function would modify the window structures.
   ## returns TRUE if the windows would be modified, and FALSE otherwise.
@@ -806,14 +802,12 @@ proc resize_term_ext*(lines, columns: cint): ErrCode {.cdecl, discardable, dynli
   ## with the application.
 
 #key_defined: check if a keycode is defined
-#https://invisible-island.net/ncurses/man/key_defined.3x.html
 proc key_defined*(definition: cstring): cint {.cdecl, importc, discardable, dynlib: libncurses.}
   ## If the string is bound to a keycode, its value (greater than zero) is
   ## returned. If no keycode is bound, zero is returned. If the string
   ## conflicts with longer strings which are bound to keys, -1 is returned.
 
 #keybound: return definition of keycode
-#https://invisible-island.net/ncurses/man/keybound.3x.html
 proc keybound*(keycode, count: cint): cstring {.cdecl, importc, discardable, dynlib: libncurses.}
   ## The keycode parameter must be greater than zero, else NULL is returned.
   ## If it does not correspond to a defined key, then NULL is returned. The
@@ -822,19 +816,18 @@ proc keybound*(keycode, count: cint): cstring {.cdecl, importc, discardable, dyn
   ## returns a string which must be freed by the caller.
 
 #keyok: enable or disable a keycode
-#https://invisible-island.net/ncurses/man/keyok.3x.html
-proc keyok(keycode: cint; enable: bool): ErrCode {.cdecl, importc, discardable, dynlib: libncurses.}
+#[
+proc keyok(keycode: cint; enable: bool): ErrCode {.cdecl, importc, discardable, dynlib: libncurses.} ## Not used?
   ## The keycode must be greater than zero, else ERR is returned. If it
   ## does not correspond to a defined key, then ERR is returned. If the
   ## enable parameter is true, then the key must have been disabled, and
   ## vice versa. Otherwise, the function returns OK.
+]#
 
 #mcprint: ship binary data to printer
-#https://invisible-island.net/ncurses/man/curs_print.3x.html
 proc mcprint*(data: cstring; len: cint): ErrCode {.cdecl, importc, discardable, dynlib: libncurses.}
 
 #move: move window cursor
-#https://invisible-island.net/ncurses/man/curs_move.3x.html
 proc move*(y, x: cint): ErrCode {.cdecl, importc, discardable, dynlib: libncurses.}
   ## Moves the cursor of stdscr to the specified coordinates.
   ## @Param: 'y' the line to move the cursor to.
@@ -843,7 +836,6 @@ proc move*(y, x: cint): ErrCode {.cdecl, importc, discardable, dynlib: libncurse
 proc wmove*(win: PWindow; y,x: cint): ErrCode {.cdecl, importc, discardable, dynlib: libncurses.}
 
 #printw: print formatted output in windows
-#https://invisible-island.net/ncurses/man/curs_printw.3x.html
 proc printw*(fmt: cstring): ErrCode {.cdecl, importc, discardable, dynlib: libncurses, varargs.}
   ## Prints out a formatted string to the stdscr.
   ## @Param: 'formattedString' the string with formatting to be output to stdscr.
@@ -865,7 +857,6 @@ proc mvwprintw*(win: PWindow; y,x: cint; fmt: cstring): ErrCode {.cdecl, importc
 proc vw_printw*(win: PWindow; fmt: cstring; varglist: varargs[cstring]): ErrCode {.cdecl, importc, discardable, dynlib: libncurses}
 
 #scanw: convert formatted input from a window
-#https://invisible-island.net/ncurses/man/curs_scanw.3x.html
 proc scanw*(fmt: cstring): ErrCode {.cdecl, importc, discardable, dynlib: libncurses, varargs.}
   ## Converts formatted input from the stdscr.
   ## @Param: 'formattedInput' Contains the fields for the input to be mapped to.
@@ -876,7 +867,6 @@ proc mvwscanw*(win: PWindow; y,x: cint; fmt: cstring): ErrCode {.cdecl, importc,
 proc vw_scanw*(win: PWindow; fmt: cstring; varglist: varargs[cstring]): ErrCode {.cdecl, importc, discardable, dynlib: libncurses, varargs,.}
 
 #pad: create and display pads
-#https://invisible-island.net/ncurses/man/curs_pad.3x.html
 proc newpad*(nlines, ncols: cint): PWindow {.cdecl, importc, discardable, dynlib: libncurses.}
 proc subpad*(orig: PWindow; lines, columns, begin_y, begin_x: cint): PWindow {.cdecl, importc, discardable, dynlib: libncurses.}
 proc prefresh*(pad: PWindow;
@@ -893,25 +883,29 @@ proc pechochar*(pad: PWindow; ch: chtype): ErrCode {.cdecl, importc, discardable
 proc pecho_wchar*(pad: PWindow; wch: WideCString): ErrCode {.cdecl, importc, discardable, dynlib: libncurses.}
 
 #scr_dump: read (write) a screen from (to) a file
-#https://invisible-island.net/ncurses/man/curs_scr_dump.3x.html
 proc scr_dump*(filename: cstring): ErrCode {.cdecl, importc, discardable, dynlib: libncurses.}
 proc scr_restore*(filename: cstring): ErrCode {.cdecl, importc, discardable, dynlib: libncurses.}
 proc scr_init*(filename: cstring): ErrCode {.cdecl, importc, discardable, dynlib: libncurses.}
 proc scr_set*(filename: cstring): ErrCode {.cdecl, importc, discardable, dynlib: libncurses.}
 
 #scroll: scroll a window
-#https://invisible-island.net/ncurses/man/curs_scroll.3x.html
 proc scroll*(win: PWindow): ErrCode {.cdecl, importc, discardable, dynlib: libncurses.}
 proc scrl*(n: cint): ErrCode {.cdecl, importc, discardable, dynlib: libncurses.}
 proc wscrl*(win: PWindow; n: cint): ErrCode {.cdecl, importc, discardable, dynlib: libncurses.}
 
 #termcap: direct interface to the terminfo capability database
-#https://invisible-island.net/ncurses/man/curs_termcap.3x.html
 var
   PC* {.importc, dynlib: libncurses.}: cchar
+    ## Set by tgetent to the terminfo entry's pad_char value.
+    ## Used in the tdelay_output function.
   UP* {.importc, dynlib: libncurses.}: ptr cchar
+    ## Set by tgetent to the terminfo entry's cursor_up value.
+    ## Not used by ncurses.
   BC* {.importc, dynlib: libncurses.}: ptr cchar
+    ## Set by tgetent to the terminfo entry's backspace_if_not_bs value.
+    ## Used in the tgoto() emulation.
   ospeed* {.importc, dynlib: libncurses.}: cshort
+    ## Set by ncurses in a system-specific coding to reflect the terminal speed.
 proc tgetent*(np, name: cstring): cint {.cdecl, importc, discardable, dynlib: libncurses.}
 proc tgetflag*(id: cstring): ErrCode {.cdecl, importc, discardable, dynlib: libncurses.}
 proc tgetnum*(id: cstring): ErrCode {.cdecl, importc, discardable, dynlib: libncurses.}
@@ -920,14 +914,12 @@ proc tgoto*(cap: cstring; col, row: cint): cstring {.cdecl, importc, discardable
 proc tputs*(str: cstring; affcnt: cint; putc: ptr proc(ch: cint): cint): ErrCode {.cdecl, importc, discardable, dynlib: libncurses.}
 
 #legacy_coding: override locale-encoding checks
-#https://invisible-island.net/ncurses/man/legacy_coding.3x.html
 proc use_legacy_coding*(level: cint): cint {.cdecl, importc, discardable, dynlib: libncurses.}
   ## If  the  screen has not been initialized, or the level parameter is out
   ## of range, the function returns ERR. Otherwise, it returns the previous
   ## level: 0, 1 or 2.
 
 #wresize: resize a curses window
-#https://invisible-island.net/ncurses/man/wresize.3x.html
 proc wresize*(win: PWindow; line, column: cint): ErrCode {.cdecl, importc, discardable, dynlib: libncurses.}
 
 # mouse interface
@@ -984,99 +976,99 @@ const
   BUTTON_ALT*   = NCURSES_MOUSE_MASK(6, 4)
   
   # keys
-  KEY_CODE_YES*  = 0o400           # A wchar_t contains a key code
-  KEY_MIN*       = 0o401           # Minimum curses key
-  KEY_BREAK*     = 0o401           # Break key (unreliable)
-  KEY_SRESET*    = 0o530           # Soft (partial) reset (unreliable)
-  KEY_RESET*     = 0o531           # Reset or hard reset (unreliable)
+  KEY_CODE_YES*  = 0o400     ## A wchar_t contains a key code
+  KEY_MIN*       = 0o401     ## Minimum curses key
+  KEY_BREAK*     = 0o401     ## Break key (unreliable)
+  KEY_SRESET*    = 0o530     ## Soft (partial) reset (unreliable)
+  KEY_RESET*     = 0o531     ## Reset or hard reset (unreliable)
 
-  KEY_DOWN*      = 0o402           # down-arrow key
-  KEY_UP*        = 0o403           # up-arrow key
-  KEY_LEFT*      = 0o404           # left-arrow key
-  KEY_RIGHT*     = 0o405           # right-arrow key
-  KEY_HOME*      = 0o406           # home key
-  KEY_BACKSPACE* = 0o407           # backspace key
-  KEY_F0*        = 0o410           # Function keys.  Space for 64
-  KEY_DL*        = 0o510           # delete-line key
-  KEY_IL*        = 0o511           # insert-line key
-  KEY_DC*        = 0o512           # delete-character key
-  KEY_IC*        = 0o513           # insert-character key
-  KEY_EIC*       = 0o514           # sent by rmir or smir in insert mode
-  KEY_CLEAR*     = 0o515           # clear-screen or erase key
-  KEY_EOS*       = 0o516           # clear-to-end-of-screen key
-  KEY_EOL*       = 0o517           # clear-to-end-of-line key
-  KEY_SF*        = 0o520           # scroll-forward key
-  KEY_SR*        = 0o521           # scroll-backward key
-  KEY_NPAGE*     = 0o522           # next-page key
-  KEY_PPAGE*     = 0o523           # previous-page key
-  KEY_STAB*      = 0o524           # set-tab key
-  KEY_CTAB*      = 0o525           # clear-tab key
-  KEY_CATAB*     = 0o526           # clear-all-tabs key
-  KEY_ENTER*     = 0o527           # enter/send key
-  KEY_PRINT*     = 0o532           # print key
-  KEY_LL*        = 0o533           # lower-left key (home down)
-  KEY_A1*        = 0o534           # upper left of keypad
-  KEY_A3*        = 0o535           # upper right of keypad
-  KEY_B2*        = 0o536           # center of keypad
-  KEY_C1*        = 0o537           # lower left of keypad
-  KEY_C3*        = 0o540           # lower right of keypad
-  KEY_BTAB*      = 0o541           # back-tab key
-  KEY_BEG*       = 0o542           # begin key
-  KEY_CANCEL*    = 0o543           # cancel key
-  KEY_CLOSE*     = 0o544           # close key
-  KEY_COMMAND*   = 0o545           # command key
-  KEY_COPY*      = 0o546           # copy key
-  KEY_CREATE*    = 0o547           # create key
-  KEY_END*       = 0o550           # end key
-  KEY_EXIT*      = 0o551           # exit key
-  KEY_FIND*      = 0o552           # find key
-  KEY_HELP*      = 0o553           # help key
-  KEY_MARK*      = 0o554           # mark key
-  KEY_MESSAGE*   = 0o555           # message key
-  KEY_MOVE*      = 0o556           # move key
-  KEY_NEXT*      = 0o557           # next key
-  KEY_OPEN*      = 0o560           # open key
-  KEY_OPTIONS*   = 0o561           # options key
-  KEY_PREVIOUS*  = 0o562           # previous key
-  KEY_REDO*      = 0o563           # redo key
-  KEY_REFERENCE* = 0o564           # reference key
-  KEY_REFRESH*   = 0o565           # refresh key
-  KEY_REPLACE*   = 0o566           # replace key
-  KEY_RESTART*   = 0o567           # restart key
-  KEY_RESUME*    = 0o570           # resume key
-  KEY_SAVE*      = 0o571           # save key
-  KEY_SBEG*      = 0o572           # shifted begin key
-  KEY_SCANCEL*   = 0o573           # shifted cancel key
-  KEY_SCOMMAND*  = 0o574           # shifted command key
-  KEY_SCOPY*     = 0o575           # shifted copy key
-  KEY_SCREATE*   = 0o576           # shifted create key
-  KEY_SDC*       = 0o577           # shifted delete-character key
-  KEY_SDL*       = 0o600           # shifted delete-line key
-  KEY_SELECT*    = 0o601           # select key
-  KEY_SEND*      = 0o602           # shifted end key
-  KEY_SEOL*      = 0o603           # shifted clear-to-end-of-line key
-  KEY_SEXIT*     = 0o604           # shifted exit key
-  KEY_SFIND*     = 0o605           # shifted find key
-  KEY_SHELP*     = 0o606           # shifted help key
-  KEY_SHOME*     = 0o607           # shifted home key
-  KEY_SIC*       = 0o610           # shifted insert-character key
-  KEY_SLEFT*     = 0o611           # shifted left-arrow key
-  KEY_SMESSAGE*  = 0o612           # shifted message key
-  KEY_SMOVE*     = 0o613           # shifted move key
-  KEY_SNEXT*     = 0o614           # shifted next key
-  KEY_SOPTIONS*  = 0o615           # shifted options key
-  KEY_SPREVIOUS* = 0o616           # shifted previous key
-  KEY_SPRINT*    = 0o617           # shifted print key
-  KEY_SREDO*     = 0o620           # shifted redo key
-  KEY_SREPLACE*  = 0o621           # shifted replace key
-  KEY_SRIGHT*    = 0o622           # shifted right-arrow key
-  KEY_SRSUME*    = 0o623           # shifted resume key
-  KEY_SSAVE*     = 0o624           # shifted save key
-  KEY_SSUSPEND*  = 0o625           # shifted suspend key
-  KEY_SUNDO*     = 0o626           # shifted undo key
-  KEY_SUSPEND*   = 0o627           # suspend key
-  KEY_UNDO*      = 0o630           # undo key
-  KEY_MOUSE*     = 0o631           # Mouse event has occurred
-  KEY_RESIZE*    = 0o632           # Terminal resize event
-  KEY_EVENT*     = 0o633           # We were interrupted by an event
+  KEY_DOWN*      = 0o402     ## down-arrow key
+  KEY_UP*        = 0o403     ## up-arrow key
+  KEY_LEFT*      = 0o404     ## left-arrow key
+  KEY_RIGHT*     = 0o405     ## right-arrow key
+  KEY_HOME*      = 0o406     ## home key
+  KEY_BACKSPACE* = 0o407     ## backspace key
+  KEY_F0*        = 0o410     ## Function keys.  Space for 64
+  KEY_DL*        = 0o510     ## delete-line key
+  KEY_IL*        = 0o511     ## insert-line key
+  KEY_DC*        = 0o512     ## delete-character key
+  KEY_IC*        = 0o513     ## insert-character key
+  KEY_EIC*       = 0o514     ## sent by rmir or smir in insert mode
+  KEY_CLEAR*     = 0o515     ## clear-screen or erase key
+  KEY_EOS*       = 0o516     ## clear-to-end-of-screen key
+  KEY_EOL*       = 0o517     ## clear-to-end-of-line key
+  KEY_SF*        = 0o520     ## scroll-forward key
+  KEY_SR*        = 0o521     ## scroll-backward key
+  KEY_NPAGE*     = 0o522     ## next-page key
+  KEY_PPAGE*     = 0o523     ## previous-page key
+  KEY_STAB*      = 0o524     ## set-tab key
+  KEY_CTAB*      = 0o525     ## clear-tab key
+  KEY_CATAB*     = 0o526     ## clear-all-tabs key
+  KEY_ENTER*     = 0o527     ## enter/send key
+  KEY_PRINT*     = 0o532     ## print key
+  KEY_LL*        = 0o533     ## lower-left key (home down)
+  KEY_A1*        = 0o534     ## upper left of keypad
+  KEY_A3*        = 0o535     ## upper right of keypad
+  KEY_B2*        = 0o536     ## center of keypad
+  KEY_C1*        = 0o537     ## lower left of keypad
+  KEY_C3*        = 0o540     ## lower right of keypad
+  KEY_BTAB*      = 0o541     ## back-tab key
+  KEY_BEG*       = 0o542     ## begin key
+  KEY_CANCEL*    = 0o543     ## cancel key
+  KEY_CLOSE*     = 0o544     ## close key
+  KEY_COMMAND*   = 0o545     ## command key
+  KEY_COPY*      = 0o546     ## copy key
+  KEY_CREATE*    = 0o547     ## create key
+  KEY_END*       = 0o550     ## end key
+  KEY_EXIT*      = 0o551     ## exit key
+  KEY_FIND*      = 0o552     ## find key
+  KEY_HELP*      = 0o553     ## help key
+  KEY_MARK*      = 0o554     ## mark key
+  KEY_MESSAGE*   = 0o555     ## message key
+  KEY_MOVE*      = 0o556     ## move key
+  KEY_NEXT*      = 0o557     ## next key
+  KEY_OPEN*      = 0o560     ## open key
+  KEY_OPTIONS*   = 0o561     ## options key
+  KEY_PREVIOUS*  = 0o562     ## previous key
+  KEY_REDO*      = 0o563     ## redo key
+  KEY_REFERENCE* = 0o564     ## reference key
+  KEY_REFRESH*   = 0o565     ## refresh key
+  KEY_REPLACE*   = 0o566     ## replace key
+  KEY_RESTART*   = 0o567     ## restart key
+  KEY_RESUME*    = 0o570     ## resume key
+  KEY_SAVE*      = 0o571     ## save key
+  KEY_SBEG*      = 0o572     ## shifted begin key
+  KEY_SCANCEL*   = 0o573     ## shifted cancel key
+  KEY_SCOMMAND*  = 0o574     ## shifted command key
+  KEY_SCOPY*     = 0o575     ## shifted copy key
+  KEY_SCREATE*   = 0o576     ## shifted create key
+  KEY_SDC*       = 0o577     ## shifted delete-character key
+  KEY_SDL*       = 0o600     ## shifted delete-line key
+  KEY_SELECT*    = 0o601     ## select key
+  KEY_SEND*      = 0o602     ## shifted end key
+  KEY_SEOL*      = 0o603     ## shifted clear-to-end-of-line key
+  KEY_SEXIT*     = 0o604     ## shifted exit key
+  KEY_SFIND*     = 0o605     ## shifted find key
+  KEY_SHELP*     = 0o606     ## shifted help key
+  KEY_SHOME*     = 0o607     ## shifted home key
+  KEY_SIC*       = 0o610     ## shifted insert-character key
+  KEY_SLEFT*     = 0o611     ## shifted left-arrow key
+  KEY_SMESSAGE*  = 0o612     ## shifted message key
+  KEY_SMOVE*     = 0o613     ## shifted move key
+  KEY_SNEXT*     = 0o614     ## shifted next key
+  KEY_SOPTIONS*  = 0o615     ## shifted options key
+  KEY_SPREVIOUS* = 0o616     ## shifted previous key
+  KEY_SPRINT*    = 0o617     ## shifted print key
+  KEY_SREDO*     = 0o620     ## shifted redo key
+  KEY_SREPLACE*  = 0o621     ## shifted replace key
+  KEY_SRIGHT*    = 0o622     ## shifted right-arrow key
+  KEY_SRSUME*    = 0o623     ## shifted resume key
+  KEY_SSAVE*     = 0o624     ## shifted save key
+  KEY_SSUSPEND*  = 0o625     ## shifted suspend key
+  KEY_SUNDO*     = 0o626     ## shifted undo key
+  KEY_SUSPEND*   = 0o627     ## suspend key
+  KEY_UNDO*      = 0o630     ## undo key
+  KEY_MOUSE*     = 0o631     ## Mouse event has occurred
+  KEY_RESIZE*    = 0o632     ## Terminal resize event
+  KEY_EVENT*     = 0o633     ## We were interrupted by an event
 template KEY_F*(n: untyped): untyped= (KEY_F0+(n)) ## Value of function key n

--- a/ncurses.nim
+++ b/ncurses.nim
@@ -11,7 +11,6 @@ else:
 type
   # 32 or 64
   chtype*  = cuint ## Holds a character and possibly an attribute
-  mmask_t* = uint32
   # ...must be at least as wide as chtype
   attr_t*  = chtype ## Attribute
 
@@ -21,8 +20,8 @@ type
     ext_color: cint
 
   ldat = object ## line data
-  
-  window* = win_st
+  Screen* = object
+  Window* = win_st
   win_st = object ## window struct
     cury*, curx*: cshort      # current cursor position
     
@@ -55,7 +54,7 @@ type
     
     # these are used only if this is a sub-window
     pary*, parx*: cint        # y, x coordinates of this window in parent
-    parent*: ptr window       # pointer to parent if a sub-window
+    parent*: ptr Window       # pointer to parent if a sub-window
     
     # these are used only if this is a pad
     pad*: pdat
@@ -68,7 +67,8 @@ type
     pad_top*,    pad_left*:  cshort
     pad_bottom*, pad_right*: cshort
 
-  MEVENT* = object ## mouse event
+  mmask_t* = uint32
+  Mevent* = object ## mouse event
     id*: cshort               # ID to distinguish multiple devices
     x*, y*, z*: cint          # event coordinates (character-cell)
     bstate*: mmask_t          # button state bits
@@ -99,21 +99,21 @@ template PAIR_NUMBER*(a: untyped): untyped =
 
 #add_wchs: Adding complex characters to a window
 proc add_wch*(wch: ptr cchar_t): ErrCode {.ncurses, importc: "add_wch".}
-proc wadd_wch*(win: ptr window, wch: ptr cchar_t): ErrCode {.ncurses, importc: "wadd_wch".}
+proc wadd_wch*(win: ptr Window, wch: ptr cchar_t): ErrCode {.ncurses, importc: "wadd_wch".}
 proc mvadd_wch*(y, x: cint, wch: ptr cchar_t): ErrCode {.ncurses, importc: "mvadd_wch".}
-proc mvwadd_wch*(win: ptr window, y, x: cint, wch: ptr cchar_t): ErrCode {.ncurses, importc: "mvwadd_wch".}
+proc mvwadd_wch*(win: ptr Window, y, x: cint, wch: ptr cchar_t): ErrCode {.ncurses, importc: "mvwadd_wch".}
 proc echo_wchar*(wch: ptr cchar_t): ErrCode {.ncurses, importc: "echo_wchar".}
-proc wech_wchar*(win: ptr window, wch: ptr cchar_t): ErrCode {.ncurses, importc: "wech_wchar".}
+proc wech_wchar*(win: ptr Window, wch: ptr cchar_t): ErrCode {.ncurses, importc: "wech_wchar".}
 
 #add_wchstr: Adding an array of complex characters to a window
 proc add_wchstr*(wchstr: ptr cchar_t): ErrCode {.ncurses, importc: "add_wchstr".}
 proc add_wchnstr*(wchstr: ptr cchar_t, numberOfCharacters: cint): ErrCode {.ncurses, importc: "add_wchnstr".}
-proc wadd_wchstr*(win: ptr window, wchstr: ptr cchar_t): ErrCode {.ncurses, importc: "wadd_wchstr".}
-proc wadd_wchnstr*(win: ptr window, wchstr: ptr cchar_t, n: cint): ErrCode {.ncurses, importc: "wadd_wchnstr".}
+proc wadd_wchstr*(win: ptr Window, wchstr: ptr cchar_t): ErrCode {.ncurses, importc: "wadd_wchstr".}
+proc wadd_wchnstr*(win: ptr Window, wchstr: ptr cchar_t, n: cint): ErrCode {.ncurses, importc: "wadd_wchnstr".}
 proc mvadd_wchstr*(y, x: cint, wchstr: ptr cchar_t): ErrCode {.ncurses, importc: "mvadd_wchstr".}
 proc mvadd_wchnstr*(y, x: cint, wchstr: ptr cchar_t, n: cint): ErrCode {.ncurses, importc: "mvadd_wchnstr".}
-proc mvwadd_wchstr*(win: ptr window, y, x: cint, wchstr: ptr cchar_t): ErrCode {.ncurses, importc: "mvwadd_wchstr".}
-proc mvwadd_wchnstr*(win: ptr window, y, x: cint, wchstr: ptr cchar_t, n: cint): ErrCode {.ncurses, importc: "mvwadd_wchnstr".}
+proc mvwadd_wchstr*(win: ptr Window, y, x: cint, wchstr: ptr cchar_t): ErrCode {.ncurses, importc: "mvwadd_wchstr".}
+proc mvwadd_wchnstr*(win: ptr Window, y, x: cint, wchstr: ptr cchar_t, n: cint): ErrCode {.ncurses, importc: "mvwadd_wchnstr".}
 
 #addch: Adding a character (with attributes) to a window
 proc addch*(character: chtype): ErrCode {.ncurses, importc: "addch".}
@@ -121,21 +121,21 @@ proc addch*(character: chtype): ErrCode {.ncurses, importc: "addch".}
   ## the current window position to the next position.
   ## @Param: 'character' the character to put into the current window.
   ## @Returns: ERR on failure and OK upon successful completion.
-proc waddch*(win: ptr window, ch: chtype): ErrCode {.ncurses, importc: "waddch".}
+proc waddch*(win: ptr Window, ch: chtype): ErrCode {.ncurses, importc: "waddch".}
 proc mvaddch*(y, x: cint, ch: chtype): ErrCode {.ncurses, importc: "mvaddch".}
-proc mvwaddch*(win: ptr window, y, x: int, ch: chtype): ErrCode {.ncurses, importc: "mvwaddch".}
+proc mvwaddch*(win: ptr Window, y, x: int, ch: chtype): ErrCode {.ncurses, importc: "mvwaddch".}
 proc echochar*(ch: chtype): ErrCode {.ncurses, importc: "echochar".}
-proc wechochar*(win: ptr window, ch: chtype): ErrCode {.ncurses, importc: "wechochar".}
+proc wechochar*(win: ptr Window, ch: chtype): ErrCode {.ncurses, importc: "wechochar".}
 
 #addchstr: Adding a string of characters (and attributes) to a window
 proc addchstr*(chstr: ptr chtype): ErrCode {.ncurses, importc: "addchstr".}
 proc addchnstr*(chstr: ptr chtype, n: cint): ErrCode {.ncurses, importc: "addchnstr".}
-proc waddchstr*(win: ptr window, chstr: ptr chtype): ErrCode {.ncurses, importc: "waddchstr".}
-proc waddchnstr*(win: ptr window, chstr: ptr chtype, n: cint): ErrCode {.ncurses, importc: "waddchnstr".}
+proc waddchstr*(win: ptr Window, chstr: ptr chtype): ErrCode {.ncurses, importc: "waddchstr".}
+proc waddchnstr*(win: ptr Window, chstr: ptr chtype, n: cint): ErrCode {.ncurses, importc: "waddchnstr".}
 proc mvaddchstr*(y, x: cint, chstr: ptr chtype): ErrCode {.ncurses, importc: "mvaddchstr".}
 proc mvaddchnstr*(y, x: cint, chstr: ptr chtype, n: cint): ErrCode {.ncurses, importc: "mvaddchnstr".}
-proc mvwaddchstr*(win: ptr window, y, x: cint, chstr: ptr chtype): ErrCode {.ncurses, importc: "mvwaddchstr".}
-proc mvwaddchnstr*(win: ptr window, y, x: cint, chstr: ptr chtype, n: cint): ErrCode {.ncurses, importc: "mvwaddchnstr".}
+proc mvwaddchstr*(win: ptr Window, y, x: cint, chstr: ptr chtype): ErrCode {.ncurses, importc: "mvwaddchstr".}
+proc mvwaddchnstr*(win: ptr Window, y, x: cint, chstr: ptr chtype, n: cint): ErrCode {.ncurses, importc: "mvwaddchnstr".}
 
 #addstr: Adding a string of characters to a window (cstring)
 proc addstr*(str: cstring): ErrCode {.ncurses, importc: "addstr".}
@@ -143,12 +143,12 @@ proc addstr*(str: cstring): ErrCode {.ncurses, importc: "addstr".}
   ## @Param: The string to add the stdscr.
   ## @Returns: ERR on failure and OK upon successful completion.
 proc addnstr*(str: cstring, n: cint): ErrCode {.ncurses, importc: "addnstr".}
-proc waddstr*(win: ptr window; str: cstring): ErrCode {.ncurses, importc: "waddstr".}
+proc waddstr*(win: ptr Window; str: cstring): ErrCode {.ncurses, importc: "waddstr".}
   ## Writes a string to the specified window.
   ## @Param: 'destinationWindow' the window to write the string to.
   ## @Param: 'stringToWrite'
   ## @Returns: ERR on failure and OK upon successful completion.
-proc waddnstr*(win: ptr window, str: cstring, n: cint): ErrCode {.ncurses, importc: "waddnstr".}
+proc waddnstr*(win: ptr Window, str: cstring, n: cint): ErrCode {.ncurses, importc: "waddnstr".}
 proc mvaddstr*(y, x: cint; str: cstring): ErrCode {.ncurses, importc: "mvaddstr".}
   ## Moves the cursor to the specified position and outputs the provided string.
   ## The cursor is then advanced to the next position.
@@ -157,18 +157,18 @@ proc mvaddstr*(y, x: cint; str: cstring): ErrCode {.ncurses, importc: "mvaddstr"
   ## @Param: 'stringToOutput' the string to put into the current window.
   ## @Returns: ERR on failure and OK upon successful completion.
 proc mvaddnstr*(y, x: cint, str: cstring, n: cint): ErrCode {.ncurses, importc: "mvaddnstr".}
-proc mvwaddstr*(win: ptr window, y, x: int, str: cstring): ErrCode {.ncurses, importc: "mvwaddstr".}
-proc mvwaddnstr*(win: ptr window, y, x: int, str: cstring, n: cint): ErrCode {.ncurses, importc: "mvwaddnstr".}
+proc mvwaddstr*(win: ptr Window, y, x: int, str: cstring): ErrCode {.ncurses, importc: "mvwaddstr".}
+proc mvwaddnstr*(win: ptr Window, y, x: int, str: cstring, n: cint): ErrCode {.ncurses, importc: "mvwaddnstr".}
 
 #addwstr: Adding a string of wide characters to a window (WideCString)
 proc addwstr(wstr: WideCString): ErrCode {.ncurses, importc: "addwstr".}
 proc addnwstr(wstr: WideCString, n: cint): ErrCode {.ncurses, importc: "addnwstr".}
-proc waddwstr(win: ptr window, wstr: WideCString): ErrCode {.ncurses, importc: "waddwstr".}
-proc waddnwstr(win: ptr window, wstr: WideCString, n: cint): ErrCode {.ncurses, importc: "waddnwstr".}
-proc mvaddwstr(y, x: cint, win: ptr window, wstr: WideCString): ErrCode {.ncurses, importc: "mvaddwstr".}
-proc mvaddnwstr(y, x: cint, win: ptr window, wstr: WideCString, n: cint): ErrCode {.ncurses, importc: "mvaddnwstr".}
-proc mvwaddwstr(win: ptr window, y, x: cint, wstr: WideCString): ErrCode {.ncurses, importc: "mvwaddwstr".}
-proc mvwaddnwstr(win: ptr window, y, x: cint, wstr: WideCString, n: cint): ErrCode {.ncurses, importc: "mvwaddnwstr".}
+proc waddwstr(win: ptr Window, wstr: WideCString): ErrCode {.ncurses, importc: "waddwstr".}
+proc waddnwstr(win: ptr Window, wstr: WideCString, n: cint): ErrCode {.ncurses, importc: "waddnwstr".}
+proc mvaddwstr(y, x: cint, win: ptr Window, wstr: WideCString): ErrCode {.ncurses, importc: "mvaddwstr".}
+proc mvaddnwstr(y, x: cint, win: ptr Window, wstr: WideCString, n: cint): ErrCode {.ncurses, importc: "mvaddnwstr".}
+proc mvwaddwstr(win: ptr Window, y, x: cint, wstr: WideCString): ErrCode {.ncurses, importc: "mvwaddwstr".}
+proc mvwaddnwstr(win: ptr Window, y, x: cint, wstr: WideCString, n: cint): ErrCode {.ncurses, importc: "mvwaddnwstr".}
 
 #new_pair: Color-pair functions
 proc alloc_pair*(fg, bg: cint): ErrCode {.ncurses, importc: "".}
@@ -205,41 +205,41 @@ const
   A_ITALIC*      = NCURSES_BITS(u1, 22) #2147483648
 
 proc attr_get*(attrs: ptr attr_t, pair: ptr cshort, opts: pointer): ErrCode {.ncurses, importc: "attr_get".}
-proc wattr_get*(win: ptr window, attrs: ptr attr_t, pair: ptr cshort, opts: pointer): ErrCode {.ncurses, importc: "wattr_get".}
+proc wattr_get*(win: ptr Window, attrs: ptr attr_t, pair: ptr cshort, opts: pointer): ErrCode {.ncurses, importc: "wattr_get".}
 proc attr_set*(attrs: attr_t, pair: cshort, opts: pointer): ErrCode {.ncurses, importc: "attr_set".}
-proc wattr_set*(win: ptr window, attrs: attr_t, pair: cshort, opts: pointer): ErrCode {.ncurses, importc: "wattr_set".}
+proc wattr_set*(win: ptr Window, attrs: attr_t, pair: cshort, opts: pointer): ErrCode {.ncurses, importc: "wattr_set".}
 proc attr_off*(attrs: attr_t, opts: pointer): ErrCode {.ncurses, importc: "attr_off".}
-proc wattr_off*(win: ptr window, attrs: attr_t, opts: pointer): ErrCode {.ncurses, importc: "wattr_off".}
+proc wattr_off*(win: ptr Window, attrs: attr_t, opts: pointer): ErrCode {.ncurses, importc: "wattr_off".}
 proc attr_on*(attrs: attr_t, opts: pointer): ErrCode {.ncurses, importc: "attr_on".}
-proc wattr_on*(win: ptr window, attrs: attr_t, opts: pointer): ErrCode {.ncurses, importc: "wattr_on".}
+proc wattr_on*(win: ptr Window, attrs: attr_t, opts: pointer): ErrCode {.ncurses, importc: "wattr_on".}
 proc attroff*(attrs: cint): ErrCode {.ncurses, importc: "attroff".}
   ## Turns off the named attributes without affecting any other attributes.
   ## @Param: 'attributes' the attributes to turn off for the current window.
   ## @Returns: An integer value, but the returned value does not have any meaning and can
   ## thus be ignored.
-proc wattroff*(win: ptr window, attrs: cint): ErrCode {.ncurses, importc: "wattroff".}
+proc wattroff*(win: ptr Window, attrs: cint): ErrCode {.ncurses, importc: "wattroff".}
 proc attron*(attrs: cint): ErrCode {.ncurses, importc: "attron".}
   ## Turns on the named attributes without affecting any other attributes.
   ## @Param: 'attributes' the attributes to turn on for the current window.
   ## @Returns: An integer value, but the returned value does not have any meaning and can
   ## thus be ignored.
-proc wattron*(win: ptr window, attrs: cint): ErrCode {.ncurses, importc: "wattron".}
+proc wattron*(win: ptr Window, attrs: cint): ErrCode {.ncurses, importc: "wattron".}
 proc attrset*(attrs: cint): ErrCode {.ncurses, importc: "attrset".}
   ## Sets the current attributes of the given window to the provided attributes.
   ## @Param: 'attributes', the attributes to apply to the current window.
   ## @Returns: An integer value, but the returned value does not have any meaning and can
   ## thus be ignored.
-proc wattrset*(win: ptr window, attrs: cint): ErrCode {.ncurses, importc: "wattrset".}
+proc wattrset*(win: ptr Window, attrs: cint): ErrCode {.ncurses, importc: "wattrset".}
 proc chgat*(n: cint, attr: attr_t, pair: cshort, opts: pointer): ErrCode {.ncurses, importc: "chgat".}
-proc wchgat*(win: ptr window, n: cint, attr: attr_t, pair: cshort, opts: pointer): ErrCode {.ncurses, importc: "wchgat".}
+proc wchgat*(win: ptr Window, n: cint, attr: attr_t, pair: cshort, opts: pointer): ErrCode {.ncurses, importc: "wchgat".}
 proc mvchgat*(y, x: cint, n: cint, attr: attr_t, pair: cshort, opts: pointer): ErrCode {.ncurses, importc: "mvchgat".}
-proc mvwchgat*(win: ptr window, y, x: cint, n: cint, attr: attr_t, pair: cshort, opts: pointer): ErrCode {.ncurses, importc: "mvwchgat".}
+proc mvwchgat*(win: ptr Window, y, x: cint, n: cint, attr: attr_t, pair: cshort, opts: pointer): ErrCode {.ncurses, importc: "mvwchgat".}
 proc color_set*(pair: cshort, opts: pointer): ErrCode {.ncurses, importc: "color_set".}
-proc wcolor_set*(win: ptr window, pair: cshort, opts: pointer): ErrCode {.ncurses, importc: "wcolor_set".}
+proc wcolor_set*(win: ptr Window, pair: cshort, opts: pointer): ErrCode {.ncurses, importc: "wcolor_set".}
 proc standend(): ErrCode {.ncurses, importc: "standend".}
-proc wstandend*(win: ptr window): ErrCode {.ncurses, importc: "wstandend".}
+proc wstandend*(win: ptr Window): ErrCode {.ncurses, importc: "wstandend".}
 proc standout*(): ErrCode {.ncurses, importc: "standout".}
-proc wstandout*(win: ptr window): ErrCode {.ncurses, importc: "wstandout".}
+proc wstandout*(win: ptr Window): ErrCode {.ncurses, importc: "wstandout".}
 
 #termattrs: Enviroment query routines
 proc baudrate*(): cint {.ncurses, importc: "baudrate".}
@@ -265,47 +265,47 @@ proc flash*(): ErrCode {.ncurses, importc: "flash".}
 
 #bkgd: Window background manipulation routines
 proc bkgdset*(ch: chtype): void {.ncurses, importc: "bkgdset".}
-proc wbkgdset*(win: ptr window, ch: chtype): void {.ncurses, importc: "wbkgdset".}
+proc wbkgdset*(win: ptr Window, ch: chtype): void {.ncurses, importc: "wbkgdset".}
 proc bkgd*(ch: chtype): ErrCode {.ncurses, importc: "bkgd".}
   ## Sets the background property of the current window and apply this setting to every
   ## character position in the window.
   ## @Param: 'background' the background property to apply.
-proc wbkgd*(win: ptr window, ch: chtype): ErrCode {.ncurses, importc: "wbkgd".}
-proc getbkgd*(win: ptr window): chtype {.ncurses, importc: "getbkgd".}
+proc wbkgd*(win: ptr Window, ch: chtype): ErrCode {.ncurses, importc: "wbkgd".}
+proc getbkgd*(win: ptr Window): chtype {.ncurses, importc: "getbkgd".}
 
 #bkgrnd: Window complex background manipulation routines
 proc bkgrnd*(wch: cchar_t): ErrCode {.ncurses, importc: "bkgrnd".}
-proc wbkgrnd*(win: ptr window, wch: cchar_t): ErrCode {.ncurses, importc: "wbkgrnd".}
+proc wbkgrnd*(win: ptr Window, wch: cchar_t): ErrCode {.ncurses, importc: "wbkgrnd".}
 proc bkgrndset*(wch: cchar_t): void {.ncurses, importc: "bkgrndset".}
-proc wbkgrndset*(win: ptr window, wch: cchar_t): void {.ncurses, importc: "getbkgrnd".}
+proc wbkgrndset*(win: ptr Window, wch: cchar_t): void {.ncurses, importc: "getbkgrnd".}
 proc getbkgrnd*(wch: cchar_t): ErrCode {.ncurses, importc: "getbkgrnd".}
-proc wgetbkgrnd*(win: ptr window, wch: cchar_t): ErrCode {.ncurses, importc: "wgetbkgrnd".}
+proc wgetbkgrnd*(win: ptr Window, wch: cchar_t): ErrCode {.ncurses, importc: "wgetbkgrnd".}
 
 #border: Create borders, horizontal and vertical lines
 proc border*(ls, rs, ts, bs, tl, tr, bl, br: chtype): ErrCode {.ncurses, importc: "border".}
-proc wborder*(win: ptr window, ls, rs, ts, bs, tl, tr, bl, br: chtype): ErrCode {.ncurses, importc: "wborder".}
-proc box*(win: ptr window, verch, horch: chtype): ErrCode {.ncurses, importc: "box".}
+proc wborder*(win: ptr Window, ls, rs, ts, bs, tl, tr, bl, br: chtype): ErrCode {.ncurses, importc: "wborder".}
+proc box*(win: ptr Window, verch, horch: chtype): ErrCode {.ncurses, importc: "box".}
 proc hline*(ch: chtype, n: cint): ErrCode {.ncurses, importc: "hline".}
-proc whline*(win: ptr window, ch: chtype, n: cint): ErrCode {.ncurses, importc: "whline".}
+proc whline*(win: ptr Window, ch: chtype, n: cint): ErrCode {.ncurses, importc: "whline".}
 proc vline*(ch: chtype, n: cint): ErrCode {.ncurses, importc: "vline".}
-proc wvline*(win: ptr window, ch: chtype, n: cint): ErrCode {.ncurses, importc: "wvline".}
+proc wvline*(win: ptr Window, ch: chtype, n: cint): ErrCode {.ncurses, importc: "wvline".}
 proc mvhline*(y, x: cint, ch: chtype, n: cint): ErrCode {.ncurses, importc: "mvhline".}
-proc mvwhline*(win: ptr window, y, x: cint, ch: chtype, n: cint): ErrCode {.ncurses, importc: "mvwhline".}
+proc mvwhline*(win: ptr Window, y, x: cint, ch: chtype, n: cint): ErrCode {.ncurses, importc: "mvwhline".}
 proc mvvline*(y, x: cint, ch: chtype, n: cint): ErrCode {.ncurses, importc: "mvvline".}
-proc mvwvline*(win: ptr window, y, x: cint, ch: chtype, n: cint): ErrCode {.ncurses, importc: "mvwvline".}
+proc mvwvline*(win: ptr Window, y, x: cint, ch: chtype, n: cint): ErrCode {.ncurses, importc: "mvwvline".}
 
 #borderset: Create borders or lines using complex characters and renditions
 proc border_set*(ls, rs, ts, bs, tl, tr, bl, br: cchar_t): ErrCode {.ncurses, importc: "border_set".}
-proc wborder_set*(win: ptr window, ls, rs, ts, bs, tl, tr, bl, br: cchar_t): ErrCode {.ncurses, importc: "wborder_set".}
-proc box_set*(win: ptr window, verch, horch: cchar_t): ErrCode {.ncurses, importc: "box_set".}
+proc wborder_set*(win: ptr Window, ls, rs, ts, bs, tl, tr, bl, br: cchar_t): ErrCode {.ncurses, importc: "wborder_set".}
+proc box_set*(win: ptr Window, verch, horch: cchar_t): ErrCode {.ncurses, importc: "box_set".}
 proc hline_set*(wch: cchar_t, n: cint): ErrCode {.ncurses, importc: "hline_set".}
-proc whline_set*(win: ptr window, wch: cchar_t, n: cint): ErrCode {.ncurses, importc: "whline_set".}
+proc whline_set*(win: ptr Window, wch: cchar_t, n: cint): ErrCode {.ncurses, importc: "whline_set".}
 proc mvhline_set*(y,x: cint, wch: cchar_t, n: cint): ErrCode {.ncurses, importc: "mvhline_set".}
-proc mvwhline_set*(win: ptr window, y,x: cint, wch: cchar_t, n: cint): ErrCode {.ncurses, importc: "mvwhline_set".}
+proc mvwhline_set*(win: ptr Window, y,x: cint, wch: cchar_t, n: cint): ErrCode {.ncurses, importc: "mvwhline_set".}
 proc vline_set*(wch: cchar_t, n: cint): ErrCode {.ncurses, importc: "vline_set".}
-proc wvline_set*(win: ptr window, wch: cchar_t, n: cint): ErrCode {.ncurses, importc: "wvline_set".}
+proc wvline_set*(win: ptr Window, wch: cchar_t, n: cint): ErrCode {.ncurses, importc: "wvline_set".}
 proc mvvline_set*(y,x: cint, wch: cchar_t, n: cint): ErrCode {.ncurses, importc: "mvvline_set".}
-proc mvwvline_set*(win: ptr window, y,x: cint, wch: cchar_t, n: cint): ErrCode {.ncurses, importc: "mvwvline_set".}
+proc mvwvline_set*(win: ptr Window, y,x: cint, wch: cchar_t, n: cint): ErrCode {.ncurses, importc: "mvwvline_set".}
 
 #inopts: Input options
 proc cbreak*(): ErrCode {.ncurses, importc: "cbreak".}
@@ -320,44 +320,44 @@ proc noecho*(): ErrCode {.ncurses, importc: "noecho".}
 proc onecho*(): ErrCode {.ncurses, importc: "echo".}
   ## Previously `echo`, but this being a Nim's print function, is changed to `onecho`
 proc halfdelay*(tenths: cint): ErrCode {.ncurses, importc: "halfdelay".}
-proc keypad*(win: ptr window, bf: bool): cint {.ncurses, importc: "keypad".}
-proc meta*(win: ptr window, bf: bool): ErrCode {.ncurses, importc: "meta".}
-proc nodelay*(win: ptr window, bf: bool): cint {.ncurses, importc: "nodelay".}
+proc keypad*(win: ptr Window, bf: bool): cint {.ncurses, importc: "keypad".}
+proc meta*(win: ptr Window, bf: bool): ErrCode {.ncurses, importc: "meta".}
+proc nodelay*(win: ptr Window, bf: bool): cint {.ncurses, importc: "nodelay".}
 proc raw*(): ErrCode {.ncurses, importc: "raw".}
 proc noraw*(): ErrCode {.ncurses, importc: "noraw".}
 proc noqiflush*(): void {.ncurses, importc: "noqiflush".}
 proc qiflush*(): void {.ncurses, importc: "qiflush".}
 proc notimeout*(): ErrCode {.ncurses, importc: "notimeout".}
 proc timeout*(delay: cint): void {.ncurses, importc: "timeout".}
-proc wtimeout*(win: ptr window, delay: cint): void {.ncurses, importc: "wtimeout".}
+proc wtimeout*(win: ptr Window, delay: cint): void {.ncurses, importc: "wtimeout".}
 proc typeahead*(fd: cint): ErrCode {.ncurses, importc: "typeahead".}
 
 #clear: Clear all or part of a window
 proc erase*(): ErrCode {.ncurses, importc: "erase".}
-proc werase*(win: ptr window): ErrCode {.ncurses, importc: "werase".}
+proc werase*(win: ptr Window): ErrCode {.ncurses, importc: "werase".}
 proc clear*(): ErrCode {.ncurses, importc: "clear".}
-proc wclear*(win: ptr window): ErrCode {.ncurses, importc: "wclear".}
+proc wclear*(win: ptr Window): ErrCode {.ncurses, importc: "wclear".}
 proc clrtobot*(): ErrCode {.ncurses, importc: "clrtobot".}
-proc wclrtobot*(win: ptr window): ErrCode {.ncurses, importc: "wclrtobot".}
+proc wclrtobot*(win: ptr Window): ErrCode {.ncurses, importc: "wclrtobot".}
 proc clrtoeol*(): ErrCode {.ncurses, importc: "clrtoeol".}
-proc wclrtoeol*(win: ptr window): ErrCode {.ncurses, importc: "wclrtoeol".}
+proc wclrtoeol*(win: ptr Window): ErrCode {.ncurses, importc: "wclrtoeol".}
 
 #outopts: Output options
-proc clearok*(win: ptr window, bf: bool): ErrCode {.ncurses, importc: "clearok".}
-proc idlok*(win: ptr window, bf: bool): ErrCode {.ncurses, importc: "idlok".}
-proc idcok*(win: ptr window, bf: bool): void {.ncurses, importc: "idcok".}
-proc immedok*(win: ptr window, bf: bool): void {.ncurses, importc: "immedok".}
-proc leaveok*(win: ptr window, bf: bool): ErrCode {.ncurses, importc: "leaveok".}
+proc clearok*(win: ptr Window, bf: bool): ErrCode {.ncurses, importc: "clearok".}
+proc idlok*(win: ptr Window, bf: bool): ErrCode {.ncurses, importc: "idlok".}
+proc idcok*(win: ptr Window, bf: bool): void {.ncurses, importc: "idcok".}
+proc immedok*(win: ptr Window, bf: bool): void {.ncurses, importc: "immedok".}
+proc leaveok*(win: ptr Window, bf: bool): ErrCode {.ncurses, importc: "leaveok".}
 proc setscrreg*(top, bot: cint): ErrCode {.ncurses, importc: "setscrreg".}
-proc wsetscrreg*(win: ptr window, top, bot: cint): ErrCode {.ncurses, importc: "wsetscrreg".}
-proc scrollok*(win: ptr window, bf: bool): ErrCode {.ncurses, importc: "scrollok".}
+proc wsetscrreg*(win: ptr Window, top, bot: cint): ErrCode {.ncurses, importc: "wsetscrreg".}
+proc scrollok*(win: ptr Window, bf: bool): ErrCode {.ncurses, importc: "scrollok".}
 proc nl*(): ErrCode {.ncurses, importc: "nl".}
 proc nonl*(): ErrCode {.ncurses, importc: "nonl".}
 
 #overlay: overlay and manipulate overlapped windows
-proc overlay*(srcwin, dstwin: ptr window): ErrCode {.ncurses, importc: "overlay".}
-proc overwrite*(srcwin, dstwin: ptr window): ErrCode {.ncurses, importc: "overwrite".}
-proc copywin*(srcwin, dstwin: ptr window,
+proc overlay*(srcwin, dstwin: ptr Window): ErrCode {.ncurses, importc: "overlay".}
+proc overwrite*(srcwin, dstwin: ptr Window): ErrCode {.ncurses, importc: "overwrite".}
+proc copywin*(srcwin, dstwin: ptr Window,
   sminrow, smincol,
   dminrow, dmincol,
   dmaxrow, dmaxcol: cint
@@ -372,7 +372,7 @@ proc resetty*(): ErrCode {.ncurses, importc: "resetty".}
 proc savetty*(): ErrCode {.ncurses, importc: "savetty".}
 proc getsyx*(y,x: cint): void {.ncurses, importc: "getsyx".}
 proc setsyx*(y,x: cint): void {.ncurses, importc: "setsyx".}
-proc ripoffline*(line: cint, init: proc(win: ptr window, cols: cint): cint): ErrCode {.ncurses, importc: "ripoffline".}
+proc ripoffline*(line: cint, init: proc(win: ptr Window, cols: cint): cint): ErrCode {.ncurses, importc: "ripoffline".}
 proc curs_set*(visibility: cint): cint {.ncurses, importc: "curs_set".}
 proc napms*(ms: cint): cint {.ncurses, importc: "napms".}
     ## Used to sleep for the specified milliseconds.
@@ -387,14 +387,295 @@ proc use_extended_names*(enable: bool): cint {.ncurses, importc: "use_extended_n
 proc define_key*(definition: cstring, keycode: cint): ErrCode {.ncurses, importc: "define_key".}
 
 #terminfo: interfaces to terminfo database
-var
-  boolnames {.ncurses, importc: "boolnames".}: cstringArray
+#[
+type
+  TERMTYPE = object
+    term_names, str_table: cstring
+    booleans: ptr bool
+    numbers: ptr cint
+    strings: cstringArray
+    term_names_table: cstring
+    ext_Names: cstringArray
+    num_Booleans, num_Numbers, num_Strings: cushort
+    ext_Booleans, ext_Numbers, ext_Strings: cushort
+  TERMTYPE2 = TERMTYPE
+  TERMINAL = object
+    `type`: TERMTYPE
+    filedes: cshort #yeaaaaah don't feel like adding terminfo ()
+  #if interested:
+  #https://invisible-island.net/ncurses/man/curs_terminfo.3x.html
+  #look in /usr/include/term.h
+]#
 
+#util: misc utility routines
+proc unctrl*(c: chtype): cstring {.ncurses, importc: "unctrl".}
+proc wunctrl*(c: ptr cchar_t): WideCString {.ncurses, importc: "wunctrl".}
+proc keyname*(c: cint): cstring {.ncurses, importc: "keyname".}
+proc keyname_wch*(w: WideCString): cstring {.ncurses, importc: "key_name".} ## previously key_name, had to be renamed.
+proc filter*(): void {.ncurses, importc: "filter".}
+proc nofilter*(): void {.ncurses, importc: "nofilter".}
+proc use_env*(f: bool): void {.ncurses, importc: "use_env".}
+proc use_tioctl*(f: bool): void {.ncurses, importc: "use_tioctl".}
+proc putwin*(win: ptr Window, filep: File): ErrCode {.ncurses, importc: "putwin".}
+proc getwin*(filep: File): ptr Window {.ncurses, importc: "getwin".}
+proc delay_output*(ms: cint): ErrCode {.ncurses, importc: "delay_output".}
+proc flushinp*(): cint {.ncurses, importc: "flushinp".}
 
+#delch: delete character under the cursor in a window
+proc delch*(): cint {.ncurses, importc: "delch".}
+  ## Delete the character under the cursor in the stdscr.
+  ## @Returns: ERR on failure and OK upon successfully flashing.
+proc wdelch*(win: ptr Window): ErrCode {.ncurses, importc: "wdelch".}
+proc mvdelch*(y,x: cint): ErrCode {.ncurses, importc: "mvdelch".}
+proc mvwdelch*(win: ptr Window, y,x: cint): ErrCode {.ncurses, importc: "mvwdelch".}
 
+#deleteln: delete and insert lines in a window
+proc deleteln*(): cint {.ncurses, importc: "deleteln".}
+  ## Deletes the line under the cursor in the stdscr. All lines below the current line are moved up one line.
+  ## The bottom line of the window is cleared and the cursor position does not change.
+  ## @Returns: ERR on failure and OK upon successful completion.
+proc wdeleteln*(win: ptr Window): ErrCode {.ncurses, importc: "wdeleteln".}
+proc insdeln*(): ErrCode {.ncurses, importc: "insdeln".}
+proc winsdeln*(win: ptr Window, n: int): ErrCode {.ncurses, importc: "winsdeln".}
+proc insertln*(): cint {.ncurses, importc: "insertln".}
+  ## Inserts a blank line above the current line in stdscr and the bottom line is lost.
+  ## @Returns: ERR on failure and OK upon successful completion.
+proc winsertln*(win: ptr Window): ErrCode {.ncurses, importc: "winsertln".}
 
+#iniscr: screen initialization and manipulation routines
+proc initscr*(): ptr Window {.ncurses, importc: "initscr".}
+  ## Usually the first curses routine to be called when initialising a program
+  ## The initscr code determines the terminal type and initialises  all curses data structures.  initscr also causes the
+  ## first call to refresh to clear the screen.
+  ## @Returns: A pointer to stdscr is returned if the operation is successful.
+  ## @Note: If errors occur, initscr writes an appropriate error message to
+  ## standard error and exits.
+proc endwin*(): ErrCode {.ncurses, importc: "endwin".}
+  ## A program should always call endwin before exiting or escaping from curses mode temporarily. This routine
+  ## restores tty modes, moves the cursor to the lower left-hand corner of the screen and resets the terminal into the
+  ## proper non-visual mode. Calling refresh or doupdate after a temporary escape causes the program to resume visual mode.
+  ## @Returns: ERR on failure and OK upon successful completion.
+proc isendwin*(): bool {.ncurses, importc: "isendwin".}
+proc newterm*(`type`: cstring, outfd, infd: File): ptr Screen {.ncurses, importc: "newterm".}
+proc set_term*(`new`: ptr Screen): ptr Screen {.ncurses, importc: "set_term".}
+proc delscreen*(sp: ptr Screen): void {.ncurses, importc: "delscreen".}
 
+#window: create a window
+proc newwin*(nlines, ncols, begin_y, begin_x: cint): ptr Window {.ncurses, importc: "newwin".}
+proc delwin*(win: ptr Window): ErrCode {.ncurses, importc: "delwin".}
+proc mvwin*(win: ptr Window, y,x: cint): ErrCode {.ncurses, importc: "mvwin".}
+proc subwin*(orig: ptr Window, nlines, ncols, begin_y, begin_x: cint): ptr Window {.ncurses, importc: "subwin".}
+proc derwin*(orig: ptr Window, nlines, ncols, begin_y, begin_x: cint): ptr Window {.ncurses, importc: "derwin".}
+proc mvderwin*(win: ptr Window, par_y, par_x: cint): ErrCode {.ncurses, importc: "mvderwin".}
+proc dupwin*(win: ptr Window): ptr Window {.ncurses, importc: "dupwin".}
+proc wsyncup*(win: ptr Window): void {.ncurses, importc: "wsyncup".}
+proc syncok*(win: ptr Window, bf: bool): ErrCode {.ncurses, importc: "syncok".}
+proc wcursyncup*(win: ptr Window): void {.ncurses, importc: "wcursynup".}
+proc wsyncdown*(win: ptr Window): void {.ncurses, importc: "wsyncdown".}
 
+#refresh: refresh windows and lines
+proc refresh*(): cint {.ncurses, importc: "refresh".}
+  ## Must be called to get actual output to the terminal. refresh uses stdscr has the default window.
+  ## @Returns: ERR on failure and OK upon successful completion.
+proc wrefresh*(win: ptr Window): cint {.ncurses, importc: "wrefresh".}
+proc wnoutrefresh*(win: ptr Window): ErrCode {.ncurses, importc: "wnoutrefresh".}
+proc doupdate*(): ErrCode {.ncurses, importc: "doupdate".}
+proc redrawwin*(win: ptr Window): ErrCode {.ncurses, importc: "redrawwin".}
+proc wredrawln*(win: ptr Window, beg_lines, num_lines: cint): ErrCode {.ncurses, importc: "wredrawln".}
+
+#slk: soft label routines
+proc slk_init*(fmt: cint): ErrCode {.ncurses, importc: "slk_init".}
+proc slk_set*(labnum: cint, label: WideCString, fmt: cint): ErrCode {.ncurses, importc: "slk_set".}
+proc slk_wset*(labnum: cint, label: WideCString, fmt: cint): ErrCode {.ncurses, importc: "slk_wset".}
+proc slk_label*(labnum: cint): cstring {.ncurses, importc: "slk_label".}
+proc slk_refresh*(): ErrCode {.ncurses, importc: "slk_refresh".}
+proc slk_noutrefresh*(): ErrCode {.ncurses, importc: "slk_noutrefresh".}
+proc slk_clear*(): ErrCode {.ncurses, importc: "slk_clear".}
+proc slk_restore*(): ErrCode {.ncurses, importc: "slk_restore".}
+proc slk_touch*(): ErrCode {.ncurses, importc: "slk_touch".}
+proc slk_attron_ch*(attrs: chtype): ErrCode {.ncurses, importc: "slk_attron".}
+proc slk_attroff_ch*(attrs: chtype): ErrCode {.ncurses, importc: "slk_attroff".}
+proc slk_attrset_ch*(attrs: chtype): ErrCode {.ncurses, importc: "slk_attrset".}
+proc slk_attr_on*(attrs: attr_t, opts: pointer): ErrCode {.ncurses, importc: "slk_attr_on".}
+proc slk_attr_off*(attrs: attr_t, opts: pointer): ErrCode {.ncurses, importc: "slk_attr_off".}
+proc slk_attr_set*(attrs: attr_t, pair: cshort, opts: pointer): ErrCode {.ncurses, importc: "slk_attr_set".}
+proc slk_attr*(): attr_t {.ncurses, importc: "slk_attr".}
+proc slk_color*(pair: cshort): ErrCode {.ncurses, importc: "slk_color".}
+proc extended_slk_color*(pair: cint): ErrCode {.ncurses, importc: "extended_slk_color".}
+
+#get_wch: get (or push back) a wide character from a terminal keyboard
+proc get_wch*(wch: WideCString): ErrCode {.ncurses, importc: "get_wch".}
+proc wget_wch*(win: ptr Window, wch: WideCString): ErrCode {.ncurses, importc: "wget_wsch".}
+proc mvget_wch*(y,x: cint, wch: WideCString): ErrCode {.ncurses, importc: "mvget_wch".}
+proc mvwget_wch*(win: ptr Window, y,x: cint, wch: WideCString): ErrCode {.ncurses, importc: "mvwget_wch".}
+proc unget_wch*(wch: WideCString): ErrCode {.ncurses, importc: "unget_wch".}
+
+#get_wstr: get an array of wide characters from a terminal keyboard
+proc get_wstr*(wstr: WideCString): ErrCode {.ncurses, importc: "get_wstr".}
+proc getn_wstr*(wstr: WideCString, n: cint): ErrCode {.ncurses, importc: "getn_wstr".}
+proc wget_wstr*(win: ptr Window, wstr: WideCString): ErrCode {.ncurses, importc: "wget_wsch".}
+proc wgetn_wstr*(win: ptr Window, wstr: WideCString, n: cint): ErrCode {.ncurses, importc: "wgetn_wsch".}
+proc mvget_wstr*(y,x: cint, wstr: WideCString): ErrCode {.ncurses, importc: "mvget_wstr".}
+proc mvgetn_wstr*(y,x: cint, wstr: WideCString, n: cint): ErrCode {.ncurses, importc: "mvgetn_wstr".}
+proc mvwget_wstr*(win: ptr Window, y,x: cint, wstr: WideCString): ErrCode {.ncurses, importc: "mvwget_wstr".}
+proc mvwgetn_wstr*(win: ptr Window, y,x: cint, wstr: WideCString, n: cint): ErrCode {.ncurses, importc: "mvwgetn_wstr".}
+
+#legacy: get cursor and window coordinates, attributes
+proc getattrs*(win: ptr Window): cint {.ncurses, importc: "getattrs".}
+proc getbegx*(win: ptr Window): cint {.ncurses, importc: "getbegx".}
+proc getbegy*(win: ptr Window): cint {.ncurses, importc: "getbegy".}
+proc getcurx*(win: ptr Window): cint {.ncurses, importc: "getcurx".}
+proc getcury*(win: ptr Window): cint {.ncurses, importc: "getcury".}
+proc getmaxx*(win: ptr Window): cint {.ncurses, importc: "getmaxx".}
+proc getmaxy*(win: ptr Window): cint {.ncurses, importc: "getmaxy".}
+proc getparx*(win: ptr Window): cint {.ncurses, importc: "getparx".}
+proc getpary*(win: ptr Window): cint {.ncurses, importc: "getpary".}
+
+#getyx: get curses cursor and window coordinates (these are implemented as macros in ncurses.h)
+template getyx*(win: ptr Window, y, x: cint): untyped=
+  ## Reads the logical cursor location from the specified window.
+  ## @Param: 'win' the window to get the cursor location from.
+  ## @Param: 'y' stores the height of the window.
+  ## @Param: 'x' stores the width of the window.
+  (y = getcury(win); x = getcurx(win)) ## testing
+template getbegyx*(win: ptr Window, y, x: cint): untyped=
+  (y = getbegy(win); x = getbegx(win))
+template getmaxyx*(win: ptr Window, y, x: cint): untyped=
+  ## retrieves the size of the specified window in the provided y and x parameters.
+  ## @Param: 'win' the window to measure.
+  ## @Param: 'y' stores the height of the window.
+  ## @Param: 'x' stores the width of the window.
+  (y = getmaxy(win); x = getmaxx(win))
+template getparyx*(win: ptr Window, y, x: cint): untyped=
+  (y = getpary(win); x = getparx(win))
+
+#getcchar: Get a wide character string and rendition from cchar_t or set a cchar_t from a wide-character string
+proc getcchar*(wcval: ptr cchar_t, wch: WideCString, attrs: ptr attr_t, color_pair: ptr cshort, opts: pointer): ErrCode {.ncurses, importc: "getcchar".}
+proc setcchar*(wcval: ptr cchar_t, wch: WideCString, attrs: attr_t, color_pair: cshort, opts: pointer): ErrCode {.ncurses, importc: "setcchar".}
+
+#getch: get (or push back) characters from the terminal keyboard
+proc getch*(): ErrCode {.ncurses, importc: "getch".}
+  ## Read a character from the stdscr window.
+  ## @Returns: ERR on failure and OK upon successful completion.
+proc wgetch*(win: ptr Window): ErrCode {.ncurses, importc: "wgetch".}
+  ## Read a character from the specified window.
+  ## @Param: 'sourceWindow' the window to read a character from.
+  ## @Returns: ERR on failure and OK upon successful completion.
+proc mvgetch*(y,x: cint): ErrCode {.ncurses, importc: "mvgetch".}
+proc mvwgetch*(win: ptr Window, y,x: cint): ErrCode {.ncurses, importc: "mvwgetch".}
+proc ungetch*(ch: cint): ErrCode {.ncurses, importc: "ungetch".}
+proc has_key*(ch: cint): ErrCode {.ncurses, importc: "has_key".}
+
+#mouse: mouse interface
+proc has_mouse*(): bool {.ncurses, importc: "has_mouse".}
+proc getmouse*(event: ptr Mevent): ErrCode {.ncurses, importc: "getmouse".}
+proc ungetmouse*(event: ptr Mevent): ErrCode {.ncurses, importc: "ungetmouse".}
+proc mousemask*(newmask: mmask_t, oldmask: ptr mmask_t): mmask_t {.ncurses, importc: "mousemask".}
+proc wenclose*(win: ptr Window, y, x: cint): bool {.ncurses, importc: "wenclose".}
+proc mouse_trafo*(y,x: ptr cint, to_screen: bool): bool {.ncurses, importc: "mouse_trafo".}
+proc wmouse_trafo*(win: ptr Window, y,x: ptr cint, to_screen: bool): bool {.ncurses, importc: "wmouse_trafo".}
+proc mouseinterval*(erval: cint): ErrCode {.ncurses, importc: "mouseinterval".}
+
+#getstr: accept character strings from terminal keyboard
+proc getstr*(str: cstring): ErrCode {.ncurses, importc: "getstr".}
+  ## Reads the inputted characters into the provided string.
+  ## @Param: 'inputString' the variable to read the input into.
+  ## @Returns: ERR on failure and OK upon successful completion.
+proc getnstr*(str: cstring; n: cint): ErrCode {.ncurses, importc: "getnstr".}
+  ## Reads at most the specified number of characters into the provided string.
+  ## @Param: 'inputString' the variable to read the input into.
+  ## @Param: 'numberOfCharacters' the maximum number of characters to read.
+  ## @Returns: ERR on failure and OK upon successful completion.
+proc wgetstr*(win: ptr Window, str: cstring): ErrCode {.ncurses, importc: "wgetstr".}
+proc wgetnstr*(win: ptr Window, str: cstring, n: cint): ErrCode {.ncurses, importc: "wgetnstr".}
+proc mvgetstr*(y,x: cint, str: cstring): ErrCode {.ncurses, importc: "mvgetstr".}
+proc mvgetnstr*(y,x: cint, str: cstring, n: cint): ErrCode {.ncurses, importc: "mvgetnstr".}
+proc mvwgetstr*(win: ptr Window, y,x: cint, str: cstring): ErrCode {.ncurses, importc: "mvwgetstr".}
+proc mvwgetnstr*(win: ptr Window, y,x: cint, str: cstring, n: cint): ErrCode {.ncurses, importc: "mvwgetnstr".}
+
+#in_wch: extract a complex character and rendition from a window
+#https://invisible-island.net/ncurses/man/curs_in_wch.3x.html
+
+#in_wchstr: get an array of complex characters and renditions from a window
+#https://invisible-island.net/ncurses/man/curs_in_wchstr.3x.html
+
+#inch: get a character and attributes from a window
+#https://invisible-island.net/ncurses/man/curs_inch.3x.html
+
+#inchstr: get a string of characters (and attributes) from a window
+#https://invisible-island.net/ncurses/man/curs_inchstr.3x.html
+
+#instr: get a string of characters from a window
+#https://invisible-island.net/ncurses/man/curs_instr.3x.html
+
+#inwstr: get a string of wchar_t characters from a window
+#https://invisible-island.net/ncurses/man/curs_inwstr.3x.html
+
+#ins_wstr: insert a wide-character string into a window
+#https://invisible-island.net/ncurses/man/curs_ins_wstr.3x.html
+
+#ins_wch: insert a complex character and rendition into a window
+#https://invisible-island.net/ncurses/man/curs_ins_wch.3x.html
+
+#insch: insert a character before cursor in a window
+#https://invisible-island.net/ncurses/man/curs_insch.3x.html
+
+#insstr: insert string before cursor in a window
+#https://invisible-island.net/ncurses/man/curs_insstr.3x.html
+
+#opaque: window properties
+#https://invisible-island.net/ncurses/man/curs_opaque.3x.html
+
+#touch: refresh control routines
+#https://invisible-island.net/ncurses/man/curs_touch.3x.html
+
+#resizeterm: change the curses terminal size
+#https://invisible-island.net/ncurses/man/resizeterm.3x.html
+
+#key_defined: check if a keycode is defined
+#https://invisible-island.net/ncurses/man/key_defined.3x.html
+
+#keybound: return definition of keycode
+#https://invisible-island.net/ncurses/man/keybound.3x.html
+
+#keyok: enable or disable a keycode
+#https://invisible-island.net/ncurses/man/keyok.3x.html
+
+#print: ship binary data to printer
+#https://invisible-island.net/ncurses/man/curs_print.3x.html
+
+#move: move window cursor
+proc move*(y, x: cint): cint {.ncurses, importc: "move".}
+  ## Moves the cursor of stdscr to the specified coordinates.
+  ## @Param: 'y' the line to move the cursor to.
+  ## @Param: 'x' the column to move the cursor to.
+  ## @Returns: ERR on failure and OK upon successful completion.
+#MISSING: wmove
+#https://invisible-island.net/ncurses/man/curs_move.3x.html
+
+#printw: print formatted output in windows
+#https://invisible-island.net/ncurses/man/curs_printw.3x.html
+
+#scanw: convert formatted input from a window
+#https://invisible-island.net/ncurses/man/curs_scanw.3x.html
+
+#pad: create and display pads
+#https://invisible-island.net/ncurses/man/curs_pad.3x.html
+
+#scr_dump: read (write) a screen from (to) a file
+#https://invisible-island.net/ncurses/man/curs_scr_dump.3x.html
+
+#scroll: scroll a window
+#https://invisible-island.net/ncurses/man/curs_scroll.3x.html
+
+#termcap: direct interface to the terminfo capability database
+#https://invisible-island.net/ncurses/man/curs_termcap.3x.html
+
+#legacy_coding: override locale-encoding checks
+#https://invisible-island.net/ncurses/man/legacy_coding.3x.html
+
+#wresize: resize a curses window
+#https://invisible-island.net/ncurses/man/wresize.3x.html
 
 #proc *(): ErrCode {.ncurses, importc: "".}
 #proc *(): {.ncurses, importc: "".}
@@ -406,115 +687,31 @@ proc can_change_color*(): bool {.ncurses, importc: "can_change_color".}
     ## @Returns: true if the terminal supports colours and can change their definitions or
     ## false otherwise.
 
-
-proc color_content*() {.ncurses, importc: "".}
-
-proc copy*() {.ncurses, importc: "".}
-
-proc curses_version*() {.ncurses, importc: "".}
-
-proc del_curterm*() {.ncurses, importc: "".}
-proc delay_output*() {.ncurses, importc: "".}
-proc delch*(): cint {.ncurses, importc: "delch".}
-    ## Delete the character under the cursor in the stdscr.
-    ## @Returns: ERR on failure and OK upon successfully flashing.
-proc deleteln*(): cint {.ncurses, importc: "deleteln".}
-    ## Deletes the line under the cursor in the stdscr. All lines below the current line are moved up one line.
-    ## The bottom line of the window is cleared and the cursor position does not change.
-    ## @Returns: ERR on failure and OK upon successful completion.
-proc delscreen*() {.ncurses, importc: "".}
-proc delwin*(win: ptr window): cint {.ncurses, importc: "delwin".}
-proc derwin*() {.ncurses, importc: "".}
-proc doupdate*() {.ncurses, importc: "".}
-proc dupwin*() {.ncurses, importc: "".}
-proc echo*() {.ncurses, importc: "".}
-proc echo_whchar*() {.ncurses, importc: "".}
-proc echochar*() {.ncurses, importc: "".}
-proc endwin*(): cint {.ncurses, importc: "endwin".}
-    ## A program should always call endwin before exiting or escaping from curses mode temporarily. This routine
-    ## restores tty modes, moves the cursor to the lower left-hand corner of the screen and resets the terminal into the
-    ## proper non-visual mode. Calling refresh or doupdate after a temporary escape causes the program to resume visual mode.
-    ## @Returns: ERR on failure and OK upon successful completion.
-
-proc extended_color_content*() {.ncurses, importc: "".}
-proc extended_pair_content*() {.ncurses, importc: "".}
-proc extended_slk_color*() {.ncurses, importc: "".}
-proc filter*() {.ncurses, importc: "".}
-
-proc flushinp*() {.ncurses, importc: "".}
-
-proc get_wch*() {.ncurses, importc: "".}
-proc get_wstr*() {.ncurses, importc: "".}
-proc getattrs*(a2: ptr window): cint {.ncurses, importc: "getattrs".}
-proc getbegx*(a2: ptr window): cint {.ncurses, importc: "getbegx".}
-proc getbegy*(a2: ptr window): cint {.ncurses, importc: "getbegy".}
-proc getbegyx*() {.ncurses, importc: "".}
-proc getcurx*(a2: ptr window): cint {.ncurses, importc: "getcurx".}
-proc getcury*(a2: ptr window): cint {.ncurses, importc: "getcury".}
-proc getmaxx*(a2: ptr window): cint {.ncurses, importc: "getmaxx".}
-proc getmaxy*(a2: ptr window): cint {.ncurses, importc: "getmaxy".}
-proc getmaxyx*(win: ptr window, y, x: var int) =
-    ## retrieves the size of the specified window in the provided y and x parameters.
-    ## @Param: 'win' the window to measure.
-    ## @Param: 'y' stores the height of the window.
-    ## @Param: 'x' stores the width of the window.
-    y = getmaxy(win)
-    x = getmaxx(win)
-proc getparx*(a2: ptr window): cint {.ncurses, importc: "getparx".}
-proc getpary*(a2: ptr window): cint {.ncurses, importc: "getpary".}
 #proc *() {.ncurses, importc: "".}
-
-proc has_mouse*(): bool {.ncurses, importc: "has_mouse".}
-proc getmouse*(a2: ptr MEVENT): cint {.ncurses, importc: "getmouse".}
-proc ungetmouse*(a2: ptr MEVENT): cint {.ncurses, importc: "ungetmouse".}
-proc mousemask*(a2: mmask_t; a3: ptr mmask_t): mmask_t {.ncurses, importc: "mousemask".}
-proc wenclose*(a2: ptr window; a3: cint; a4: cint): bool {.ncurses, importc: "wenclose".}
-proc mouseinterval*(a2: cint): cint {.ncurses, importc: "mouseinterval".}
-proc wmouse_trafo*(a2: ptr window; a3: ptr cint; a4: ptr cint; a5: bool): bool {.ncurses, importc: "wmouse_trafo".}
-proc mouse_trafo*(a2: ptr cint; a3: ptr cint; a4: bool): bool {.ncurses, importc: "mouse_trafo".}
 
 # These functions are not in X/Open, but we use them in macro definitions:
 
 
 
-proc newwin*(lines, columns, begin_y, begin_x: int): ptr window {.ncurses, importc: "newwin".}
+proc newwin*(lines, columns, begin_y, begin_x: int): ptr Window {.ncurses, importc: "newwin".}
 
-proc mvwin*(win: ptr window, y, x: int): cint {.ncurses, importc: "mvwin".}
+proc mvwin*(win: ptr Window, y, x: int): cint {.ncurses, importc: "mvwin".}
 
-proc subpad*(orig: ptr window, lines, columns, begin_y, begin_x: int): ptr window {.ncurses, importc: "subpad".}
+proc subpad*(orig: ptr Window, lines, columns, begin_y, begin_x: int): ptr Window {.ncurses, importc: "subpad".}
 
-proc subwin*(orig: ptr window, lines, columns, begin_y, begin_x: int): ptr window {.ncurses, importc: "subwin".}
+proc subwin*(orig: ptr Window, lines, columns, begin_y, begin_x: int): ptr Window {.ncurses, importc: "subwin".}
 
-proc scroll*(win: ptr window): cint {.ncurses, importc: "scroll".}
+proc scroll*(win: ptr Window): cint {.ncurses, importc: "scroll".}
 
-proc wrefresh*(win: ptr window): cint {.ncurses, importc: "wrefresh".}
+proc wattron*(win: ptr Window, attributes: int64): cint {.ncurses, importc: "wattron".}
 
-proc wattron*(win: ptr window, attributes: int64): cint {.ncurses, importc: "wattron".}
+proc wattroff*(win: ptr Window, attributes: int64): cint {.ncurses, importc: "wattroff".}
 
-proc wattroff*(win: ptr window, attributes: int64): cint {.ncurses, importc: "wattroff".}
+proc wresize*(win: ptr Window, line, column: int): cint {.ncurses, importc: "wresize".}
 
-proc wresize*(win: ptr window, line, column: int): cint {.ncurses, importc: "wresize".}
-
-proc wmove*(win: ptr window, y, x: int): cint {.ncurses, importc: "wmove".}
-
-proc wprintw*(win: ptr window, formattedString: cstring): cint {.ncurses, importc: "wprintw".}
+proc wprintw*(win: ptr Window, formattedString: cstring): cint {.ncurses, importc: "wprintw".}
 
 proc set_escdelay*(size: int): cint {.ncurses, importc: "set_escdelay".}
-
-proc getch*(): cint {.ncurses, importc: "getch".}
-    ## Read a character from the stdscr window.
-    ## @Returns: ERR on failure and OK upon successful completion.
-
-proc getnstr*(inputString: cstring; numberOfCharacters: int): cint {.ncurses, importc: "getnstr".}
-    ## Reads at most the specified number of characters into the provided string.
-    ## @Param: 'inputString' the variable to read the input into.
-    ## @Param: 'numberOfCharacters' the maximum number of characters to read.
-    ## @Returns: ERR on failure and OK upon successful completion.
-
-proc getstr*(inputString: cstring): cint {.ncurses, importc: "getstr".}
-    ## Reads the inputted characters into the provided string.
-    ## @Param: 'inputString' the variable to read the input into.
-    ## @Returns: ERR on failure and OK upon successful completion.
 
 proc has_colors*(): bool {.ncurses, importc: "has_colors".}
     ## Used to determine if the terminal can manipulate colours.
@@ -529,27 +726,9 @@ proc init_pair*(pair: cshort; foreground: cshort; background: cshort): cint {.nc
     ## @Param: 'background': the background colour number.
     ## @Returns: ERR on failure and OK upon successful completion.
 
-proc initscr*(): ptr window {.ncurses, importc: "initscr".}
-    ## Usually the first curses routine to be called when initialising a program
-    ## The initscr code determines the terminal type and initialises  all curses data structures.  initscr also causes the
-    ## first call to refresh to clear the screen.
-    ## @Returns: A pointer to stdscr is returned if the operation is successful.
-    ## @Note: If errors occur, initscr writes an appropriate error message to
-    ## standard error and exits.
-
 proc insch*(character: chtype): cint {.ncurses, importc: "insch".}
     ## Inserts a character before the cursor in the stdscr.
     ## @Param: 'character' the character to insert.
-    ## @Returns: ERR on failure and OK upon successful completion.
-
-proc insertln*(): cint {.ncurses, importc: "insertln".}
-    ## Inserts a blank line above the current line in stdscr and the bottom line is lost.
-    ## @Returns: ERR on failure and OK upon successful completion.
-
-proc move*(y: int; x: int): cint {.ncurses, importc: "move".}
-    ## Moves the cursor of stdscr to the specified coordinates.
-    ## @Param: 'y' the line to move the cursor to.
-    ## @Param: 'x' the column to move the cursor to.
     ## @Returns: ERR on failure and OK upon successful completion.
 
 proc mvaddch*(y: int; x: int; character: chtype): cint {.ncurses, importc: "mvaddch".}
@@ -567,7 +746,7 @@ proc mvprintw*(y: int; x: int; formattedString: cstring): cint {.varargs, ncurse
     ## @Param: 'formattedString' the string with formatting to be output to stdscr.
     ## @Returns: ERR on failure and OK upon successful completion.
 
-proc mvwprintw*(destinationWindow: ptr window; y: int; x: int; formattedString: cstring): cint {.varargs, ncurses, importc: "mvwprintw".}
+proc mvwprintw*(destinationWindow: ptr Window; y: int; x: int; formattedString: cstring): cint {.varargs, ncurses, importc: "mvwprintw".}
     ## Prints out a formatted string to the specified window at the specified row and column.
     ## @Param: 'destinationWindow' the window to write the string to.
     ## @Param: 'y' the line to move the cursor to.
@@ -578,10 +757,6 @@ proc mvwprintw*(destinationWindow: ptr window; y: int; x: int; formattedString: 
 proc printw*(formattedString: cstring): cint {.varargs, ncurses, importc: "printw".}
     ## Prints out a formatted string to the stdscr.
     ## @Param: 'formattedString' the string with formatting to be output to stdscr.
-    ## @Returns: ERR on failure and OK upon successful completion.
-
-proc refresh*(): cint {.ncurses, importc: "refresh".}
-    ## Must be called to get actual output to the terminal. refresh uses stdscr has the default window.
     ## @Returns: ERR on failure and OK upon successful completion.
 
 proc scanw*(formattedInput: cstring): int {.varargs, ncurses, importc: "scanw".}
@@ -595,19 +770,6 @@ proc start_color*(): cint {.ncurses, importc: "start_color".}
     ## terminal was just turned on.
     ## @Note: It is good practice to call this routine right after initscr. It must be
     ## called before any other colour manipulating routines.
-
-proc wgetch*(sourceWindow: ptr window): cint {.ncurses, importc: "wgetch".}
-    ## Read a character from the specified window.
-    ## @Param: 'sourceWindow' the window to read a character from.
-    ## @Returns: ERR on failure and OK upon successful completion.
-
-proc getyx*(win: ptr window, y, x: var int) =
-    ## Reads the logical cursor location from the specified window.
-    ## @Param: 'win' the window to get the cursor location from.
-    ## @Param: 'y' stores the height of the window.
-    ## @Param: 'x' stores the width of the window.
-    y = getcury(win)
-    x = getcurx(win)
 
 # mouse interface
 template NCURSES_MOUSE_MASK(b, m: untyped): untyped = ((m) shl (((b) - 1) * 5))
@@ -759,4 +921,4 @@ const
   KEY_RESIZE*    = 0o632           # Terminal resize event
   KEY_EVENT*     = 0o633           # We were interrupted by an event
 
-template KEY_F*(n: untyped): untyped= (KEY_F0+(n))    # Value of function key n
+template KEY_F*(n: untyped): untyped= (KEY_F0+(n)) ## Value of function key n

--- a/ncurses.nim
+++ b/ncurses.nim
@@ -603,10 +603,10 @@ proc getcchar*(wcval: ptr cchar_t, wch: WideCString, attrs: ptr attr_t, color_pa
 proc setcchar*(wcval: ptr cchar_t, wch: WideCString, attrs: attr_t, color_pair: cshort, opts: pointer): ErrCode {.cdecl, importc, discardable, dynlib: libncurses.}
 
 #getch: get (or push back) characters from the terminal keyboard
-proc getch*(): ErrCode {.cdecl, importc, discardable, dynlib: libncurses.}
+proc getch*(): cchar {.cdecl, importc, discardable, dynlib: libncurses.}
   ## Read a character from the stdscr window.
   ## @Returns: ERR on failure and OK upon successful completion.
-proc wgetch*(win: PWindow): ErrCode {.cdecl, importc, discardable, dynlib: libncurses.}
+proc wgetch*(win: PWindow): cchar {.cdecl, importc, discardable, dynlib: libncurses.}
   ## Read a character from the specified window.
   ## @Param: 'sourceWindow' the window to read a character from.
   ## @Returns: ERR on failure and OK upon successful completion.
@@ -916,7 +916,7 @@ proc tputs*(str: cstring; affcnt: cint; putc: ptr proc(ch: cint): cint): ErrCode
 
 #legacy_coding: override locale-encoding checks
 proc use_legacy_coding*(level: cint): cint {.cdecl, importc, discardable, dynlib: libncurses.}
-  ## If  the  screen has not been initialized, or the level parameter is out
+  ## If the screen has not been initialized, or the level parameter is out
   ## of range, the function returns ERR. Otherwise, it returns the previous
   ## level: 0, 1 or 2.
 

--- a/ncurses.nim
+++ b/ncurses.nim
@@ -57,6 +57,7 @@ type
     yoffset: cshort          # real begy is _begy + _yoffset
     bkgrnd: cchar_t          # current background char/attribute pair
     color: cint              # current color-pair for non-space character
+  window {.deprecated: "Use Pwindow instead.".} = Window
 
   pdat = object ## pad data
     pad_y*,      pad_x*:     cshort

--- a/ncurses.nim
+++ b/ncurses.nim
@@ -18,8 +18,8 @@ type
     ext_color: cint
 
   ldat = object ## line data
-  Screen* {.importc.} = object
-  Terminal* {.importc.} = object
+  Screen* = object
+  Terminal* = object
   Window* = object ## window struct
     cury*, curx*: cshort      # current cursor position
     
@@ -72,9 +72,9 @@ type
     bstate*: mmask_t          # button state bits
   
   #not ncurses but used to make things easier
-  ErrCode = distinct cint ## Returns ERR upon failure or OK on success.
-  PWindow = ptr Window
-  PScreen = ptr Screen
+  ErrCode* = distinct cint ## Returns ERR upon failure or OK on success.
+  PWindow* = ptr Window
+  PScreen* = ptr Screen
 
 const
   ERR* = (-1)

--- a/ncurses.nim
+++ b/ncurses.nim
@@ -20,16 +20,16 @@ type
   Terminal* = object
   Window* = object ## Holds window data
     cury, curx: cshort       # current cursor position
-    
+
     # window location and size
     maxy, maxx: cshort       # maximums of x and y, NOT window size
     begy, begx: cshort       # screen coords of upper-left-hand corner
     flags: cshort            # window state flags
-    
+
     # attribute tracking
     attrs: attr_t            # current attribute for non-space character
     bkgd: chtype             # current background char/attribute pair
-    
+
     # option values set by user
     notimeout: bool          # no time out on function-key entry?
     clear: bool              # consider all data in the window invalid?
@@ -41,23 +41,23 @@ type
     sync: bool               # window in sync mode?
     use_keypad: bool         # process function keys into KEY_ symbols?
     delay: cint              # 0 = nodelay, <0 = blocking, >0 = delay
-    
+
     line: ptr ldat           # the actual line data
-    
+
     # global screen state
     regtop: cshort           # top line of scrolling region
     regbottom: cshort        # bottom line of scrolling region
-    
+
     # these are used only if this is a sub-window
     pary, parx: cint         # y, x coordinates of this window in parent
     parent: PWindow          # pointer to parent if a sub-window
-    
+
     # these are used only if this is a pad
     pad: pdat
     yoffset: cshort          # real begy is _begy + _yoffset
     bkgrnd: cchar_t          # current background char/attribute pair
     color: cint              # current color-pair for non-space character
-  window {.deprecated: "Use Pwindow instead.".} = Window
+  window* {.deprecated: "Use Pwindow instead.".} = Window
 
   pdat = object ## pad data
     pad_y*,      pad_x*:     cshort
@@ -69,15 +69,15 @@ type
     id*: cshort              # ID to distinguish multiple devices
     x*, y*, z*: cint         # event coordinates (character-cell)
     bstate*: mmask_t         # button state bits
-  
+
   #not ncurses but used to make things easier
-  ErrCode* = distinct cint ## Error Code. Returns ERR (-1) upon failure or OK (0) on success.
+  ErrCode* = cint ## Error Code. Returns ERR (-1) upon failure or OK (0) on success.
   PWindow* = ptr Window
   PScreen* = ptr Screen
 
 const
-  ERR* = (-1)
-  OK*  = (0)
+  ERR*: ErrCode = (-1)
+  OK*:  ErrCode = (0)
   NCURSES_ATTR_SHIFT = 8
 template NCURSES_CAST(`type`, value: untyped): untyped = (`type`)(value)
 template NCURSES_BITS(mask, shift: untyped): untyped =
@@ -975,7 +975,7 @@ const
   BUTTON_CTRL*  = NCURSES_MOUSE_MASK(6, 1)
   BUTTON_SHIFT* = NCURSES_MOUSE_MASK(6, 2)
   BUTTON_ALT*   = NCURSES_MOUSE_MASK(6, 4)
-  
+
   # keys
   KEY_CODE_YES*  = 0o400     ## A wchar_t contains a key code
   KEY_MIN*       = 0o401     ## Minimum curses key

--- a/ncurses.nim
+++ b/ncurses.nim
@@ -1,138 +1,85 @@
 {.deadCodeElim: on.}
 when defined(windows):
- const
-   libncurses* = "libncurses.dll"
+ const libncurses* = "libncurses.dll"
 elif defined(macosx):
- const
-   libncurses* = "libncurses.dylib"
+ const libncurses* = "libncurses.dylib"
 else:
- const
-   libncurses* = "libncursesw.so"
-type
- chtype* = int64
- mmask_t* = uint32
- attr_t* = chtype
-
-# ...must be at least as wide as chtype
+ const libncurses* = "libncursesw.so"
+{.pragma: ncurses, discardable, cdecl, dynlib: libncurses.}
 
 type
- window* = win_st
- ldat* = object
+  chtype*  = cuint #32 or 64
+  mmask_t* = uint32
+  attr_t*  = chtype # ...must be at least as wide as chtype
 
- pdat* = object
-   pad_y*: cshort
-   pad_x*: cshort
-   pad_top*: cshort
-   pad_left*: cshort
-   pad_bottom*: cshort
-   pad_right*: cshort
+  cchar_t* = object # (complex char)
+    attr: attr_t
+    chars: WideCString #5
+    ext_color: cint
 
- win_st* = object
-   cury*: cshort
-   curx*: cshort             # current cursor position
-                             # window location and size
-   maxy*: cshort
-   maxx*: cshort             # maximums of x and y, NOT window size
-   begy*: cshort
-   begx*: cshort             # screen coords of upper-left-hand corner
-   flags*: cshort            # window state flags
-                             # attribute tracking
-   attrs*: attr_t            # current attribute for non-space character
-   bkgd*: chtype             # current background char/attribute pair
-                             # option values set by user
-   notimeout*: bool          # no time out on function-key entry?
-   clear*: bool              # consider all data in the window invalid?
-   leaveok*: bool            # OK to not reset cursor on exit?
-   scroll*: bool             # OK to scroll this window?
-   idlok*: bool              # OK to use insert/delete line?
-   idcok*: bool              # OK to use insert/delete char?
-   immed*: bool              # window in immed mode? (not yet used)
-   sync*: bool               # window in sync mode?
-   use_keypad*: bool         # process function keys into KEY_ symbols?
-   delay*: cint              # 0 = nodelay, <0 = blocking, >0 = delay
-   line*: ptr ldat           # the actual line data
-                             # global screen state
-   regtop*: cshort           # top line of scrolling region
-   regbottom*: cshort        # bottom line of scrolling region
-                             # these are used only if this is a sub-window
-   parx*: cint               # x coordinate of this window in parent
-   pary*: cint               # y coordinate of this window in parent
-   parent*: ptr window       # pointer to parent if a sub-window
-                             # these are used only if this is a pad
-   pad*: pdat
-   yoffset*: cshort          # real begy is _begy + _yoffset
-   color*: cint              # current color-pair for non-space character
+  ldat = object # (line data)
+  
+  window* = win_st
+  win_st = object # (window struct)
+    cury*, curx*: cshort      # current cursor position
+    
+    # window location and size
+    maxy*, maxx*: cshort      # maximums of x and y, NOT window size
+    begy*, begx*: cshort      # screen coords of upper-left-hand corner
+    flags*: cshort            # window state flags
+    
+    # attribute tracking
+    attrs*: attr_t            # current attribute for non-space character
+    bkgd*: chtype             # current background char/attribute pair
+    
+    # option values set by user
+    notimeout*: bool          # no time out on function-key entry?
+    clear*: bool              # consider all data in the window invalid?
+    leaveok*: bool            # OK to not reset cursor on exit?
+    scroll*: bool             # OK to scroll this window?
+    idlok*: bool              # OK to use insert/delete line?
+    idcok*: bool              # OK to use insert/delete char?
+    immed*: bool              # window in immed mode? (not yet used)
+    sync*: bool               # window in sync mode?
+    use_keypad*: bool         # process function keys into KEY_ symbols?
+    delay*: cint              # 0 = nodelay, <0 = blocking, >0 = delay
+    
+    line*: ptr ldat           # the actual line data
+    
+    # global screen state
+    regtop*: cshort           # top line of scrolling region
+    regbottom*: cshort        # bottom line of scrolling region
+    
+    # these are used only if this is a sub-window
+    pary*, parx*: cint        # y, x coordinates of this window in parent
+    parent*: ptr window       # pointer to parent if a sub-window
+    
+    # these are used only if this is a pad
+    pad*: pdat
+    yoffset*: cshort          # real begy is _begy + _yoffset
+    bkgrnd*: cchar_t          # current background char/attribute pair
+    color*: cint              # current color-pair for non-space character
+  
+  pdat = object # (pad data)
+    pad_y*,      pad_x*:     cshort
+    pad_top*,    pad_left*:  cshort
+    pad_bottom*, pad_right*: cshort
 
+  MEVENT* = object # (mouse event)
+    id*: cshort               # ID to distinguish multiple devices
+    x*, y*, z*: cint          # event coordinates (character-cell)
+    bstate*: mmask_t          # button state bits
 
 var COLORS* {.importc: "COLORS", dynlib: libncurses.}: int
-
 var COLOR_PAIRS* {.importc: "COLOR_PAIRS", dynlib: libncurses.}: int
 
 const
- ERR* = (- 1)
- OK* = (0)
+  ERR* = (-1)
+  OK*  = (0)
 
-# keys
+type ErrCode = cint ## Returns ERR upon failure or OK on success.
 
-const
-  KEY_CODE_YES* = 0o400
-  KEY_MIN* = 0o401
-  KEY_BREAK* = 0o401
-  KEY_SRESET* = 0o530
-  KEY_RESET* = 0o531
-  KEY_DOWN* = 0o402
-  KEY_UP* = 0o403
-  KEY_LEFT* = 0o404
-  KEY_RIGHT* = 0o405
-
-# colors
-
-const
- COLOR_BLACK* = 0
- COLOR_RED* = 1
- COLOR_GREEN* = 2
- COLOR_YELLOW* = 3
- COLOR_BLUE* = 4
- COLOR_MAGENTA* = 5
- COLOR_CYAN* = 6
- COLOR_WHITE* = 7
-
-# attributes
-
-template NCURSES_CAST*(`type`, value: untyped): untyped =
- (`type`)(value)
-
-# attributes
-
-const
- NCURSES_ATTR_SHIFT* = 8'i64
-
-template NCURSES_BITS*(mask, shift: untyped): untyped =
- (NCURSES_CAST(int64, (mask)) shl ((shift) + NCURSES_ATTR_SHIFT))
-
-const
- A_NORMAL* = 0
- A_BOLD* = 2097152
- A_UNDERLINE* = 131072
- A_ATTRIBUTES* = 4294967040'i64
- A_CHAR_TEXT* = 255
- A_REVERSE* = 262144
- A_BLINK* = 524288
- A_DIM* = 1048576
- A_ALT_CHARSET* = 4194304
- A_INVIS* = 8388608
- A_PROTECT* = 16777216
- A_HORIZONTAL* = 33554432
- A_LEFT* = 67108864
- A_LOW* = 34217728
- A_RIGHT* = 268435456
- A_TOP* = 536870912
- A_VERTICAL* = 1073741824
- A_ITALIC* = 2147483648'i64
-
-#
-#  These apply to the first 256 color pairs.
-#
+template NCURSES_CAST(`type`, value: untyped): untyped = (`type`)(value)
 
 template COLOR_PAIR*(n: untyped): untyped =
  NCURSES_BITS((n), 0'i64)
@@ -141,307 +88,432 @@ template PAIR_NUMBER*(a: untyped): untyped =
  (NCURSES_CAST(int, ((NCURSES_CAST(uint64, (a)) and A_COLOR) shr
      NCURSES_ATTR_SHIFT)))
 
-# mouse interface
+#add_wchs: Adding complex characters to a window
+proc add_wch*(wch: ptr cchar_t): ErrCode {.ncurses, importc: "add_wch".}
+proc wadd_wch*(win: ptr window, wch: ptr cchar_t): ErrCode {.ncurses, importc: "wadd_wch".}
+proc mvadd_wch*(y, x: cint, wch: ptr cchar_t): ErrCode {.ncurses, importc: "mvadd_wch".}
+proc mvwadd_wch*(win: ptr window, y, x: cint, wch: ptr cchar_t): ErrCode {.ncurses, importc: "mvwadd_wch".}
+proc echo_wchar*(wch: ptr cchar_t): ErrCode {.ncurses, importc: "echo_wchar".}
+proc wech_wchar*(win: ptr window, wch: ptr cchar_t): ErrCode {.ncurses, importc: "wech_wchar".}
 
-template NCURSES_MOUSE_MASK*(b, m: untyped): untyped =
- ((m) shl (((b) - 1) * 5))
+#add_wchstr: Adding an array of complex characters to a window
+proc add_wchstr*(wchstr: ptr cchar_t): ErrCode {.ncurses, importc: "add_wchstr".}
+proc add_wchnstr*(wchstr: ptr cchar_t, numberOfCharacters: cint): ErrCode {.ncurses, importc: "add_wchnstr".}
+proc wadd_wchstr*(win: ptr window, wchstr: ptr cchar_t): ErrCode {.ncurses, importc: "wadd_wchstr".}
+proc wadd_wchnstr*(win: ptr window, wchstr: ptr cchar_t, n: cint): ErrCode {.ncurses, importc: "wadd_wchnstr".}
+proc mvadd_wchstr*(y, x: cint, wchstr: ptr cchar_t): ErrCode {.ncurses, importc: "mvadd_wchstr".}
+proc mvadd_wchnstr*(y, x: cint, wchstr: ptr cchar_t, n: cint): ErrCode {.ncurses, importc: "mvadd_wchnstr".}
+proc mvwadd_wchstr*(win: ptr window, y, x: cint, wchstr: ptr cchar_t): ErrCode {.ncurses, importc: "mvwadd_wchstr".}
+proc mvwadd_wchnstr*(win: ptr window, y, x: cint, wchstr: ptr cchar_t, n: cint): ErrCode {.ncurses, importc: "mvwadd_wchnstr".}
 
+#addch: Adding a character (with attributes) to a window
+proc addch*(character: chtype): ErrCode {.ncurses, importc: "addch".}
+  ## Puts a character into the stdscr at its current window position and then advances
+  ## the current window position to the next position.
+  ## @Param: 'character' the character to put into the current window.
+  ## @Returns: ERR on failure and OK upon successful completion.
+proc waddch*(win: ptr window, ch: chtype): ErrCode {.ncurses, importc: "waddch".}
+proc mvaddch*(y, x: cint, ch: chtype): ErrCode {.ncurses, importc: "mvaddch".}
+proc mvwaddch*(win: ptr window, y, x: int, ch: chtype): ErrCode {.ncurses, importc: "mvwaddch".}
+proc echochar*(ch: chtype): ErrCode {.ncurses, importc: "echochar".}
+proc wechochar*(win: ptr window, ch: chtype): ErrCode {.ncurses, importc: "wechochar".}
+
+#addchstr: Adding a string of characters (and attributes) to a window
+proc addchstr*(chstr: ptr chtype): ErrCode {.ncurses, importc: "addchstr".}
+proc addchnstr*(chstr: ptr chtype, n: cint): ErrCode {.ncurses, importc: "addchnstr".}
+proc waddchstr*(win: ptr window, chstr: ptr chtype): ErrCode {.ncurses, importc: "waddchstr".}
+proc waddchnstr*(win: ptr window, chstr: ptr chtype, n: cint): ErrCode {.ncurses, importc: "waddchnstr".}
+proc mvaddchstr*(y, x: cint, chstr: ptr chtype): ErrCode {.ncurses, importc: "mvaddchstr".}
+proc mvaddchnstr*(y, x: cint, chstr: ptr chtype, n: cint): ErrCode {.ncurses, importc: "mvaddchnstr".}
+proc mvwaddchstr*(win: ptr window, y, x: cint, chstr: ptr chtype): ErrCode {.ncurses, importc: "mvwaddchstr".}
+proc mvwaddchnstr*(win: ptr window, y, x: cint, chstr: ptr chtype, n: cint): ErrCode {.ncurses, importc: "mvwaddchnstr".}
+
+#addstr: Adding a string of characters to a window (cstring)
+proc addstr*(str: cstring): ErrCode {.ncurses, importc: "addstr".}
+  ## Adds a string of characters the the stdscr and advances the cursor.
+  ## @Param: The string to add the stdscr.
+  ## @Returns: ERR on failure and OK upon successful completion.
+proc addnstr*(str: cstring, n: cint): ErrCode {.ncurses, importc: "addnstr".}
+proc waddstr*(win: ptr window; str: cstring): ErrCode {.ncurses, importc: "waddstr".}
+  ## Writes a string to the specified window.
+  ## @Param: 'destinationWindow' the window to write the string to.
+  ## @Param: 'stringToWrite'
+  ## @Returns: ERR on failure and OK upon successful completion.
+proc waddnstr*(win: ptr window, str: cstring, n: cint): ErrCode {.ncurses, importc: "waddnstr".}
+proc mvaddstr*(y, x: cint; str: cstring): ErrCode {.ncurses, importc: "mvaddstr".}
+  ## Moves the cursor to the specified position and outputs the provided string.
+  ## The cursor is then advanced to the next position.
+  ## @Param: 'y' the line to move the cursor to.
+  ## @Param: 'x' the column to move the cursor to.
+  ## @Param: 'stringToOutput' the string to put into the current window.
+  ## @Returns: ERR on failure and OK upon successful completion.
+proc mvaddnstr*(y, x: cint, str: cstring, n: cint): ErrCode {.ncurses, importc: "mvaddnstr".}
+proc mvwaddstr*(win: ptr window, y, x: int, str: cstring): ErrCode {.ncurses, importc: "mvwaddstr".}
+proc mvwaddnstr*(win: ptr window, y, x: int, str: cstring, n: cint): ErrCode {.ncurses, importc: "mvwaddnstr".}
+
+#addwstr: Adding a string of wide characters to a window (WideCString)
+proc addwstr(wstr: WideCString): ErrCode {.ncurses, importc: "addwstr".}
+proc addnwstr(wstr: WideCString, n: cint): ErrCode {.ncurses, importc: "addnwstr".}
+proc waddwstr(win: ptr window, wstr: WideCString): ErrCode {.ncurses, importc: "waddwstr".}
+proc waddnwstr(win: ptr window, wstr: WideCString, n: cint): ErrCode {.ncurses, importc: "waddnwstr".}
+proc mvaddwstr(y, x: cint, win: ptr window, wstr: WideCString): ErrCode {.ncurses, importc: "mvaddwstr".}
+proc mvaddnwstr(y, x: cint, win: ptr window, wstr: WideCString, n: cint): ErrCode {.ncurses, importc: "mvaddnwstr".}
+proc mvwaddwstr(win: ptr window, y, x: cint, wstr: WideCString): ErrCode {.ncurses, importc: "mvwaddwstr".}
+proc mvwaddnwstr(win: ptr window, y, x: cint, wstr: WideCString, n: cint): ErrCode {.ncurses, importc: "mvwaddnwstr".}
+
+#new_pair: Color-pair functions
+proc alloc_pair*(fg, bg: cint): ErrCode {.ncurses, importc: "".}
+proc find_pair*(fg, bg: cint): ErrCode {.ncurses, importc: "".}
+proc free_pair*(pair: cint): ErrCode {.ncurses, importc: "".}
+
+#default_colors: Use terminal's default colors
+proc use_default_colors*(): ErrCode {.ncurses, importc: "use_default_colors".}
+proc assume_default_colors*(fg, bg: cint): ErrCode {.ncurses, importc: "assume_default_colors".}
+
+#attr: Character and attribute control routines
+const NCURSES_ATTR_SHIFT = 8'i64
+template NCURSES_BITS(mask, shift: untyped): untyped =
+ (NCURSES_CAST(int64, (mask)) shl ((shift) + NCURSES_ATTR_SHIFT))
 const
- NCURSES_BUTTON_RELEASED* = 1
- NCURSES_BUTTON_PRESSED* = 2
- NCURSES_BUTTON_CLICKED* = 4
- NCURSES_DOUBLE_CLICKED* = 0o000000000010
- NCURSES_TRIPLE_CLICKED* = 0o000000000020
- NCURSES_RESERVED_EVENT* = 0o000000000040
+  u1: uint = 1
+  A_NORMAL*      = (u1 - u1)            #0
+  A_BOLD*        = NCURSES_BITS(not (u1 - u1), 0)   #2097152
+  A_UNDERLINE*   = NCURSES_BITS((u1 shl 8) - u1, 0) #131072
+  A_ATTRIBUTES*  = NCURSES_BITS(u1,  8) #4294967040'i64
+  A_CHAR_TEXT*   = NCURSES_BITS(u1,  9) #255
+  A_REVERSE*     = NCURSES_BITS(u1, 10) #262144
+  A_BLINK*       = NCURSES_BITS(u1, 11) #524288
+  A_DIM*         = NCURSES_BITS(u1, 12) #1048576
+  A_ALT_CHARSET* = NCURSES_BITS(u1, 13) #4194304
+  A_INVIS*       = NCURSES_BITS(u1, 14) #8388608
+  A_PROTECT*     = NCURSES_BITS(u1, 15) #16777216
+  A_HORIZONTAL*  = NCURSES_BITS(u1, 16) #33554432
+  A_LEFT*        = NCURSES_BITS(u1, 17) #67108864
+  A_LOW*         = NCURSES_BITS(u1, 18) #34217728
+  A_RIGHT*       = NCURSES_BITS(u1, 19) #268435456
+  A_TOP*         = NCURSES_BITS(u1, 20) #536870912
+  A_VERTICAL*    = NCURSES_BITS(u1, 21) #1073741824
+  A_ITALIC*      = NCURSES_BITS(u1, 22) #2147483648
 
-# event masks
+proc attr_get*(attrs: ptr attr_t, pair: ptr cshort, opts: pointer): ErrCode {.ncurses, importc: "attr_get".}
+proc wattr_get*(win: ptr window, attrs: ptr attr_t, pair: ptr cshort, opts: pointer): ErrCode {.ncurses, importc: "wattr_get".}
+proc attr_set*(attrs: attr_t, pair: cshort, opts: pointer): ErrCode {.ncurses, importc: "attr_set".}
+proc wattr_set*(win: ptr window, attrs: attr_t, pair: cshort, opts: pointer): ErrCode {.ncurses, importc: "wattr_set".}
+proc attr_off*(attrs: attr_t, opts: pointer): ErrCode {.ncurses, importc: "attr_off".}
+proc wattr_off*(win: ptr window, attrs: attr_t, opts: pointer): ErrCode {.ncurses, importc: "wattr_off".}
+proc attr_on*(attrs: attr_t, opts: pointer): ErrCode {.ncurses, importc: "attr_on".}
+proc wattr_on*(win: ptr window, attrs: attr_t, opts: pointer): ErrCode {.ncurses, importc: "wattr_on".}
+proc attroff*(attrs: cint): ErrCode {.ncurses, importc: "attroff".}
+  ## Turns off the named attributes without affecting any other attributes.
+  ## @Param: 'attributes' the attributes to turn off for the current window.
+  ## @Returns: An integer value, but the returned value does not have any meaning and can
+  ## thus be ignored.
+proc wattroff*(win: ptr window, attrs: cint): ErrCode {.ncurses, importc: "wattroff".}
+proc attron*(attrs: cint): ErrCode {.ncurses, importc: "attron".}
+  ## Turns on the named attributes without affecting any other attributes.
+  ## @Param: 'attributes' the attributes to turn on for the current window.
+  ## @Returns: An integer value, but the returned value does not have any meaning and can
+  ## thus be ignored.
+proc wattron*(win: ptr window, attrs: cint): ErrCode {.ncurses, importc: "wattron".}
+proc attrset*(attrs: cint): ErrCode {.ncurses, importc: "attrset".}
+  ## Sets the current attributes of the given window to the provided attributes.
+  ## @Param: 'attributes', the attributes to apply to the current window.
+  ## @Returns: An integer value, but the returned value does not have any meaning and can
+  ## thus be ignored.
+proc wattrset*(win: ptr window, attrs: cint): ErrCode {.ncurses, importc: "wattrset".}
+proc chgat*(n: cint, attr: attr_t, pair: cshort, opts: pointer): ErrCode {.ncurses, importc: "chgat".}
+proc wchgat*(win: ptr window, n: cint, attr: attr_t, pair: cshort, opts: pointer): ErrCode {.ncurses, importc: "wchgat".}
+proc mvchgat*(y, x: cint, n: cint, attr: attr_t, pair: cshort, opts: pointer): ErrCode {.ncurses, importc: "mvchgat".}
+proc mvwchgat*(win: ptr window, y, x: cint, n: cint, attr: attr_t, pair: cshort, opts: pointer): ErrCode {.ncurses, importc: "mvwchgat".}
+proc color_set*(pair: cshort, opts: pointer): ErrCode {.ncurses, importc: "color_set".}
+proc wcolor_set*(win: ptr window, pair: cshort, opts: pointer): ErrCode {.ncurses, importc: "wcolor_set".}
+proc standend(): ErrCode {.ncurses, importc: "standend".}
+proc wstandend*(win: ptr window): ErrCode {.ncurses, importc: "wstandend".}
+proc standout*(): ErrCode {.ncurses, importc: "standout".}
+proc wstandout*(win: ptr window): ErrCode {.ncurses, importc: "wstandout".}
 
-const
- BUTTON1_RELEASED* = NCURSES_MOUSE_MASK(1, NCURSES_BUTTON_RELEASED)
- BUTTON1_PRESSED* = NCURSES_MOUSE_MASK(1, NCURSES_BUTTON_PRESSED)
- BUTTON1_CLICKED* = NCURSES_MOUSE_MASK(1, NCURSES_BUTTON_CLICKED)
- BUTTON1_DOUBLE_CLICKED* = NCURSES_MOUSE_MASK(1, NCURSES_DOUBLE_CLICKED)
- BUTTON1_TRIPLE_CLICKED* = NCURSES_MOUSE_MASK(1, NCURSES_TRIPLE_CLICKED)
- BUTTON2_RELEASED* = NCURSES_MOUSE_MASK(2, NCURSES_BUTTON_RELEASED)
- BUTTON2_PRESSED* = NCURSES_MOUSE_MASK(2, NCURSES_BUTTON_PRESSED)
- BUTTON2_CLICKED* = NCURSES_MOUSE_MASK(2, NCURSES_BUTTON_CLICKED)
- BUTTON2_DOUBLE_CLICKED* = NCURSES_MOUSE_MASK(2, NCURSES_DOUBLE_CLICKED)
- BUTTON2_TRIPLE_CLICKED* = NCURSES_MOUSE_MASK(2, NCURSES_TRIPLE_CLICKED)
- BUTTON3_RELEASED* = NCURSES_MOUSE_MASK(3, NCURSES_BUTTON_RELEASED)
- BUTTON3_PRESSED* = NCURSES_MOUSE_MASK(3, NCURSES_BUTTON_PRESSED)
- BUTTON3_CLICKED* = NCURSES_MOUSE_MASK(3, NCURSES_BUTTON_CLICKED)
- BUTTON3_DOUBLE_CLICKED* = NCURSES_MOUSE_MASK(3, NCURSES_DOUBLE_CLICKED)
- BUTTON3_TRIPLE_CLICKED* = NCURSES_MOUSE_MASK(3, NCURSES_TRIPLE_CLICKED)
- BUTTON4_RELEASED* = NCURSES_MOUSE_MASK(4, NCURSES_BUTTON_RELEASED)
- BUTTON4_PRESSED* = NCURSES_MOUSE_MASK(4, NCURSES_BUTTON_PRESSED)
- BUTTON4_CLICKED* = NCURSES_MOUSE_MASK(4, NCURSES_BUTTON_CLICKED)
- BUTTON4_DOUBLE_CLICKED* = NCURSES_MOUSE_MASK(4, NCURSES_DOUBLE_CLICKED)
- BUTTON4_TRIPLE_CLICKED* = NCURSES_MOUSE_MASK(4, NCURSES_TRIPLE_CLICKED)
+#termattrs: Enviroment query routines
+proc baudrate*(): cint {.ncurses, importc: "baudrate".}
+proc erasechar*() {.ncurses, importc: "erasechar".}
+proc erasewchar*(ch: WideCString) {.ncurses, importc: "erasewchar".}
+proc has_ic*(): bool {.ncurses, importc: "has_ic".}
+proc has_il*(): bool {.ncurses, importc: "has_il".}
+proc killchar*(): cchar {.ncurses, importc: "killchar".}
+proc killwchar*(ch: WideCString): char {.ncurses, importc: "killwchar".}
+proc longname*(): cstring {.ncurses, importc: "longname".}
+proc term_attrs*(): attr_t {.ncurses, importc: "term_attrs".}
+proc term_attrs_ch*(): chtype {.ncurses, importc: "termattrs".}
+  ## in C this function appears as termattr, although because of
+  ## Nim's style insensitivity this had to be changed.
+proc termname*(): cstring {.ncurses, importc: "termname".}
 
-#
-#  In 32 bits the version-1 scheme does not provide enough space for a 5th
-#  button, unless we choose to change the ABI by omitting the reserved-events.
-#
+#beep: Bell and screen flash routines
+proc beep*(): ErrCode {.ncurses, importc: "beep".}
+proc flash*(): ErrCode {.ncurses, importc: "flash".}
+  ## Flashes the screen and if that is not possible it sounds the alert. If this is not possible
+  ## nothing happens.
+  ## @Returns: ERR on failure and OK upon successfully flashing.
 
-const
- BUTTON5_RELEASED* = NCURSES_MOUSE_MASK(5, NCURSES_BUTTON_RELEASED)
- BUTTON5_PRESSED* = NCURSES_MOUSE_MASK(5, NCURSES_BUTTON_PRESSED)
- BUTTON5_CLICKED* = NCURSES_MOUSE_MASK(5, NCURSES_BUTTON_CLICKED)
- BUTTON5_DOUBLE_CLICKED* = NCURSES_MOUSE_MASK(5, NCURSES_DOUBLE_CLICKED)
- BUTTON5_TRIPLE_CLICKED* = NCURSES_MOUSE_MASK(5, NCURSES_TRIPLE_CLICKED)
- BUTTON_CTRL* = NCURSES_MOUSE_MASK(6, 1)
- BUTTON_SHIFT* = NCURSES_MOUSE_MASK(6, 2)
- BUTTON_ALT* = NCURSES_MOUSE_MASK(6, 4)
+#bkgd: Window background manipulation routines
+proc bkgdset*(ch: chtype): void {.ncurses, importc: "bkgdset".}
+proc wbkgdset*(win: ptr window, ch: chtype): void {.ncurses, importc: "wbkgdset".}
+proc bkgd*(ch: chtype): ErrCode {.ncurses, importc: "bkgd".}
+  ## Sets the background property of the current window and apply this setting to every
+  ## character position in the window.
+  ## @Param: 'background' the background property to apply.
+proc wbkgd*(win: ptr window, ch: chtype): ErrCode {.ncurses, importc: "wbkgd".}
+proc getbkgd*(win: ptr window): chtype {.ncurses, importc: "getbkgd".}
 
-template BUTTON_RELEASE*(e, x: untyped): untyped =
- ((e) and NCURSES_MOUSE_MASK(x, 1))
+#bkgrnd: Window complex background manipulation routines
+proc bkgrnd*(wch: cchar_t): ErrCode {.ncurses, importc: "bkgrnd".}
+proc wbkgrnd*(win: ptr window, wch: cchar_t): ErrCode {.ncurses, importc: "wbkgrnd".}
+proc bkgrndset*(wch: cchar_t): void {.ncurses, importc: "bkgrndset".}
+proc wbkgrndset*(win: ptr window, wch: cchar_t): void {.ncurses, importc: "getbkgrnd".}
+proc getbkgrnd*(wch: cchar_t): ErrCode {.ncurses, importc: "getbkgrnd".}
+proc wgetbkgrnd*(win: ptr window, wch: cchar_t): ErrCode {.ncurses, importc: "wgetbkgrnd".}
 
-template BUTTON_PRESS*(e, x: untyped): untyped =
- ((e) and NCURSES_MOUSE_MASK(x, 2))
+#border: Create borders, horizontal and vertical lines
+proc border*(ls, rs, ts, bs, tl, tr, bl, br: chtype): ErrCode {.ncurses, importc: "border".}
+proc wborder*(win: ptr window, ls, rs, ts, bs, tl, tr, bl, br: chtype): ErrCode {.ncurses, importc: "wborder".}
+proc box*(win: ptr window, verch, horch: chtype): ErrCode {.ncurses, importc: "box".}
+proc hline*(ch: chtype, n: cint): ErrCode {.ncurses, importc: "hline".}
+proc whline*(win: ptr window, ch: chtype, n: cint): ErrCode {.ncurses, importc: "whline".}
+proc vline*(ch: chtype, n: cint): ErrCode {.ncurses, importc: "vline".}
+proc wvline*(win: ptr window, ch: chtype, n: cint): ErrCode {.ncurses, importc: "wvline".}
+proc mvhline*(y, x: cint, ch: chtype, n: cint): ErrCode {.ncurses, importc: "mvhline".}
+proc mvwhline*(win: ptr window, y, x: cint, ch: chtype, n: cint): ErrCode {.ncurses, importc: "mvwhline".}
+proc mvvline*(y, x: cint, ch: chtype, n: cint): ErrCode {.ncurses, importc: "mvvline".}
+proc mvwvline*(win: ptr window, y, x: cint, ch: chtype, n: cint): ErrCode {.ncurses, importc: "mvwvline".}
 
-template BUTTON_CLICK*(e, x: untyped): untyped =
- ((e) and NCURSES_MOUSE_MASK(x, 4))
+#borderset: Create borders or lines using complex characters and renditions
+proc border_set*(ls, rs, ts, bs, tl, tr, bl, br: cchar_t): ErrCode {.ncurses, importc: "border_set".}
+proc wborder_set*(win: ptr window, ls, rs, ts, bs, tl, tr, bl, br: cchar_t): ErrCode {.ncurses, importc: "wborder_set".}
+proc box_set*(win: ptr window, verch, horch: cchar_t): ErrCode {.ncurses, importc: "box_set".}
+proc hline_set*(wch: cchar_t, n: cint): ErrCode {.ncurses, importc: "hline_set".}
+proc whline_set*(win: ptr window, wch: cchar_t, n: cint): ErrCode {.ncurses, importc: "whline_set".}
+proc mvhline_set*(y,x: cint, wch: cchar_t, n: cint): ErrCode {.ncurses, importc: "mvhline_set".}
+proc mvwhline_set*(win: ptr window, y,x: cint, wch: cchar_t, n: cint): ErrCode {.ncurses, importc: "mvwhline_set".}
+proc vline_set*(wch: cchar_t, n: cint): ErrCode {.ncurses, importc: "vline_set".}
+proc wvline_set*(win: ptr window, wch: cchar_t, n: cint): ErrCode {.ncurses, importc: "wvline_set".}
+proc mvvline_set*(y,x: cint, wch: cchar_t, n: cint): ErrCode {.ncurses, importc: "mvvline_set".}
+proc mvwvline_set*(win: ptr window, y,x: cint, wch: cchar_t, n: cint): ErrCode {.ncurses, importc: "mvwvline_set".}
 
-template BUTTON_DOUBLE_CLICK*(e, x: untyped): untyped =
- ((e) and NCURSES_MOUSE_MASK(x, 0o000000000010))
+#inopts: Input options
+proc cbreak*(): ErrCode {.ncurses, importc: "cbreak".}
+  ## The cbreak routine disables line buffering and erase/kill character-processing
+  ## (interrupt and flow control characters are unaffected), making characters typed by
+  ## the user immediately available to the program.
+  ## @Returns: ERR on failure and OK upon successful completion.
+proc nocbreak*(): ErrCode {.ncurses, importc: "nocbreak".}
+  ## Returns the terminal to normal (cooked mode).
+  ## @Returns: ERR on failure and OK upon successful completion.
+proc noecho*(): ErrCode {.ncurses, importc: "noecho".}
+proc onecho*(): ErrCode {.ncurses, importc: "echo".}
+  ## Previously `echo`, but this being a Nim's print function, is changed to `onecho`
+proc *(): ErrCode {.ncurses, importc: "".}
+proc *(): ErrCode {.ncurses, importc: "".}
+proc *(): ErrCode {.ncurses, importc: "".}
+proc *(): ErrCode {.ncurses, importc: "".}
+proc *(): ErrCode {.ncurses, importc: "".}
+proc *(): ErrCode {.ncurses, importc: "".}
+proc *(): ErrCode {.ncurses, importc: "".}
+proc *(): ErrCode {.ncurses, importc: "".}
+proc *(): ErrCode {.ncurses, importc: "".}
+proc *(): ErrCode {.ncurses, importc: "".}
+proc *(): ErrCode {.ncurses, importc: "".}
 
-template BUTTON_TRIPLE_CLICK*(e, x: untyped): untyped =
- ((e) and NCURSES_MOUSE_MASK(x, 0o000000000020))
 
-template BUTTON_RESERVED_EVENT*(e, x: untyped): untyped =
- ((e) and NCURSES_MOUSE_MASK(x, 0o000000000040))
 
-type
- MEVENT* = object
-   id*: cshort               # ID to distinguish multiple devices
-   x*: cint
-   y*: cint
-   z*: cint                  # event coordinates (character-cell)
-   bstate*: mmask_t          # button state bits
 
-#proc *() {.cdecl, discardable, importc: "", dynlib: libncurses.}
 
-proc add_wch*(character: chtype): cint {.cdecl, discardable, importc: "add_wch", dynlib: libncurses.}
-proc add_wchnstr*(character: chtype, numberOfCharacters: cint) {.cdecl, discardable, importc: "add_wchnstr", dynlib: libncurses.}
-proc add_wchstr*(character: chtype) {.cdecl, discardable, importc: "add_wchstr", dynlib: libncurses.}
-proc addch*(character: chtype): cint {.cdecl, discardable, importc: "addch", dynlib: libncurses.}
-    ## Puts a character into the stdscr at its current window position and then advances
-    ## the current window position to the next position.
-    ## @Param: 'character' the character to put into the current window.
-    ## @Returns: ERR on failure and OK upon successful completion.
-proc addchnstr*(character: chtype, numberOfCharacters: cint) {.cdecl, discardable, importc: "", dynlib: libncurses.}
-proc addchstr*(character: chtype) {.cdecl, discardable, importc: "", dynlib: libncurses.}
-proc addnstr*() {.cdecl, discardable, importc: "", dynlib: libncurses.}
-proc addnwstr*() {.cdecl, discardable, importc: "", dynlib: libncurses.}
-proc addstr*(stringToAdd: cstring): cint {.cdecl, discardable, importc: "addstr", dynlib: libncurses.}
-    ## Adds a string of characters the the stdscr and advances the cursor.
-    ## @Param: The string to add the stdscr.
-    ## @Returns: ERR on failure and OK upon successful completion.
-proc addwstr*() {.cdecl, discardable, importc: "", dynlib: libncurses.}
-proc alloc_pair*() {.cdecl, discardable, importc: "", dynlib: libncurses.}
-proc assume_default_colors*() {.cdecl, discardable, importc: "", dynlib: libncurses.}
-proc attr_get*() {.cdecl, discardable, importc: "", dynlib: libncurses.}
-proc attr_off*() {.cdecl, discardable, importc: "", dynlib: libncurses.}
-proc attr_on*() {.cdecl, discardable, importc: "", dynlib: libncurses.}
-proc attr_set*() {.cdecl, discardable, importc: "", dynlib: libncurses.}
-proc attroff*(attributes: int64): cint {.cdecl, discardable, importc: "attroff", dynlib: libncurses.}
-    ## Turns off the named attributes without affecting any other attributes.
-    ## @Param: 'attributes' the attributes to turn off for the current window.
-    ## @Returns: An integer value, but the returned value does not have any meaning and can
-    ## thus be ignored.
-proc attron*(attributes: int64): cint {.cdecl, discardable, importc: "attron", dynlib: libncurses.}
-    ## Turns on the named attributes without affecting any other attributes.
-    ## @Param: 'attributes' the attributes to turn on for the current window.
-    ## @Returns: An integer value, but the returned value does not have any meaning and can
-    ## thus be ignored.
-proc attrset*(attributes: int64): cint {.cdecl, discardable, importc: "attrset", dynlib: libncurses.}
-    ## Sets the current attributes of the given window to the provided attributes.
-    ## @Param: 'attributes', the attributes to apply to the current window.
-    ## @Returns: An integer value, but the returned value does not have any meaning and can
-    ## thus be ignored.
-proc baudrate*() {.cdecl, discardable, importc: "", dynlib: libncurses.}
-proc beep*(): cint {.cdecl, discardable, importc: "beep", dynlib: libncurses.}
-    ## Sounds an audible alarm on the terminal, otherwise it flashes the screen (visible bell).
-    ## @Returns: ERR on failure and OK upon successfully beeping.
-proc bkgd*(background: int64): cint {.cdecl, discardable, importc: "bkgd", dynlib: libncurses.}
-    ## Sets the background property of the current window and apply this setting to every
-    ## character position in the window.
-    ## @Param: 'background' the background property to apply.
-proc bkgdset*() {.cdecl, discardable, importc: "", dynlib: libncurses.}
-proc bkgrnd*() {.cdecl, discardable, importc: "", dynlib: libncurses.}
-proc bkgrndset*() {.cdecl, discardable, importc: "", dynlib: libncurses.}
-proc border*() {.cdecl, discardable, importc: "", dynlib: libncurses.}
-proc border_set*() {.cdecl, discardable, importc: "", dynlib: libncurses.}
-proc box*(a2: ptr window, x, y: int64): cint {.cdecl, discardable, importc: "box", dynlib: libncurses.}
-proc box_set*() {.cdecl, discardable, importc: "", dynlib: libncurses.}
-proc can_change_color*(): bool {.cdecl, importc: "can_change_color", dynlib: libncurses.}
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+#proc *(): ErrCode {.ncurses, importc: "".}
+#proc *(): {.ncurses, importc: "".}
+
+
+proc can_change_color*(): bool {.ncurses, importc: "can_change_color".}
     ## Used to determine if the terminal supports colours and can change their definitions.
     ## @Returns: true if the terminal supports colours and can change their definitions or
     ## false otherwise.
-proc cbreak*(): cint {.cdecl, discardable, importc: "cbreak", dynlib: libncurses.}
-    ## The cbreak routine disables line buffering and erase/kill character-processing
-    ## (interrupt and flow control characters are unaffected), making characters typed by
-    ## the user immediately available to the program.
-    ## @Returns: ERR on failure and OK upon successful completion.
-proc chgat*() {.cdecl, discardable, importc: "", dynlib: libncurses.}
-proc clear*(): cint {.cdecl, discardable, importc: "clear", dynlib: libncurses.}
-proc clearok*() {.cdecl, discardable, importc: "", dynlib: libncurses.}
-proc clrtobot*() {.cdecl, discardable, importc: "", dynlib: libncurses.}
-proc clrtoeol*() {.cdecl, discardable, importc: "", dynlib: libncurses.}
-proc color_content*() {.cdecl, discardable, importc: "", dynlib: libncurses.}
-proc color_set*() {.cdecl, discardable, importc: "", dynlib: libncurses.}
-proc copywin*() {.cdecl, discardable, importc: "", dynlib: libncurses.}
-proc copy*() {.cdecl, discardable, importc: "", dynlib: libncurses.}
-proc curs_set*(visibility: int): cint {.cdecl, discardable, importc: "curs_set", dynlib: libncurses.}
-proc curses_version*() {.cdecl, discardable, importc: "", dynlib: libncurses.}
-proc def_prog_mode*(): cint {.cdecl, discardable, importc: "def_prog_mode", dynlib: libncurses.}
-proc def_shell_mode*() {.cdecl, discardable, importc: "", dynlib: libncurses.}
-proc define_key*() {.cdecl, discardable, importc: "", dynlib: libncurses.}
-proc del_curterm*() {.cdecl, discardable, importc: "", dynlib: libncurses.}
-proc delay_output*() {.cdecl, discardable, importc: "", dynlib: libncurses.}
-proc delch*(): cint {.cdecl, discardable, importc: "delch", dynlib: libncurses.}
+
+
+proc clear*(): cint {.ncurses, importc: "clear".}
+proc clearok*() {.ncurses, importc: "".}
+proc clrtobot*() {.ncurses, importc: "".}
+proc clrtoeol*() {.ncurses, importc: "".}
+proc color_content*() {.ncurses, importc: "".}
+
+proc copywin*() {.ncurses, importc: "".}
+proc copy*() {.ncurses, importc: "".}
+proc curs_set*(visibility: int): cint {.ncurses, importc: "curs_set".}
+proc curses_version*() {.ncurses, importc: "".}
+proc def_prog_mode*(): cint {.ncurses, importc: "def_prog_mode".}
+proc def_shell_mode*() {.ncurses, importc: "".}
+proc define_key*() {.ncurses, importc: "".}
+proc del_curterm*() {.ncurses, importc: "".}
+proc delay_output*() {.ncurses, importc: "".}
+proc delch*(): cint {.ncurses, importc: "delch".}
     ## Delete the character under the cursor in the stdscr.
     ## @Returns: ERR on failure and OK upon successfully flashing.
-proc deleteln*(): cint {.cdecl, discardable, importc: "deleteln", dynlib: libncurses.}
+proc deleteln*(): cint {.ncurses, importc: "deleteln".}
     ## Deletes the line under the cursor in the stdscr. All lines below the current line are moved up one line.
     ## The bottom line of the window is cleared and the cursor position does not change.
     ## @Returns: ERR on failure and OK upon successful completion.
-proc delscreen*() {.cdecl, discardable, importc: "", dynlib: libncurses.}
-proc delwin*(win: ptr window): cint {.cdecl, discardable, importc: "delwin", dynlib: libncurses.}
-proc derwin*() {.cdecl, discardable, importc: "", dynlib: libncurses.}
-proc doupdate*() {.cdecl, discardable, importc: "", dynlib: libncurses.}
-proc dupwin*() {.cdecl, discardable, importc: "", dynlib: libncurses.}
-proc echo*() {.cdecl, discardable, importc: "", dynlib: libncurses.}
-proc echo_whchar*() {.cdecl, discardable, importc: "", dynlib: libncurses.}
-proc echochar*() {.cdecl, discardable, importc: "", dynlib: libncurses.}
-proc endwin*(): cint {.cdecl, discardable, importc: "endwin", dynlib: libncurses.}
+proc delscreen*() {.ncurses, importc: "".}
+proc delwin*(win: ptr window): cint {.ncurses, importc: "delwin".}
+proc derwin*() {.ncurses, importc: "".}
+proc doupdate*() {.ncurses, importc: "".}
+proc dupwin*() {.ncurses, importc: "".}
+proc echo*() {.ncurses, importc: "".}
+proc echo_whchar*() {.ncurses, importc: "".}
+proc echochar*() {.ncurses, importc: "".}
+proc endwin*(): cint {.ncurses, importc: "endwin".}
     ## A program should always call endwin before exiting or escaping from curses mode temporarily. This routine
     ## restores tty modes, moves the cursor to the lower left-hand corner of the screen and resets the terminal into the
     ## proper non-visual mode. Calling refresh or doupdate after a temporary escape causes the program to resume visual mode.
     ## @Returns: ERR on failure and OK upon successful completion.
-proc erase*(): cint {.cdecl, discardable, importc: "erase", dynlib: libncurses.}
-proc erasechar*() {.cdecl, discardable, importc: "", dynlib: libncurses.}
-proc erasewchar*() {.cdecl, discardable, importc: "", dynlib: libncurses.}
-proc extended_color_content*() {.cdecl, discardable, importc: "", dynlib: libncurses.}
-proc extended_pair_content*() {.cdecl, discardable, importc: "", dynlib: libncurses.}
-proc extended_slk_color*() {.cdecl, discardable, importc: "", dynlib: libncurses.}
-proc filter*() {.cdecl, discardable, importc: "", dynlib: libncurses.}
-proc find_pair*() {.cdecl, discardable, importc: "", dynlib: libncurses.}
-proc flash*() {.cdecl, discardable, importc: "", dynlib: libncurses.}
-proc flushinp*() {.cdecl, discardable, importc: "", dynlib: libncurses.}
-proc free_pair*() {.cdecl, discardable, importc: "", dynlib: libncurses.}
-proc get_wch*() {.cdecl, discardable, importc: "", dynlib: libncurses.}
-proc get_wstr*() {.cdecl, discardable, importc: "", dynlib: libncurses.}
-proc getattrs*(a2: ptr window): cint {.cdecl, discardable, importc: "getattrs", dynlib: libncurses.}
-proc getbegx*(a2: ptr window): cint {.cdecl, discardable, importc: "getbegx", dynlib: libncurses.}
-proc getbegy*(a2: ptr window): cint {.cdecl, discardable, importc: "getbegy", dynlib: libncurses.}
-proc getcurx*(a2: ptr window): cint {.cdecl, discardable, importc: "getcurx", dynlib: libncurses.}
-proc getcury*(a2: ptr window): cint {.cdecl, discardable, importc: "getcury", dynlib: libncurses.}
-proc getmaxx*(a2: ptr window): cint {.cdecl, discardable, importc: "getmaxx", dynlib: libncurses.}
-proc getmaxy*(a2: ptr window): cint {.cdecl, discardable, importc: "getmaxy", dynlib: libncurses.}
-proc getparx*(a2: ptr window): cint {.cdecl, discardable, importc: "getparx", dynlib: libncurses.}
-proc getpary*(a2: ptr window): cint {.cdecl, discardable, importc: "getpary", dynlib: libncurses.}
-proc *() {.cdecl, discardable, importc: "", dynlib: libncurses.}
+proc erase*(): cint {.ncurses, importc: "erase".}
 
-proc has_mouse*(): bool {.cdecl, importc: "has_mouse", dynlib: libncurses.}
-proc getmouse*(a2: ptr MEVENT): cint {.cdecl, importc: "getmouse", dynlib: libncurses.}
-proc ungetmouse*(a2: ptr MEVENT): cint {.cdecl, importc: "ungetmouse", dynlib: libncurses.}
-proc mousemask*(a2: mmask_t; a3: ptr mmask_t): mmask_t {.cdecl, importc: "mousemask", dynlib: libncurses.}
-proc wenclose*(a2: ptr window; a3: cint; a4: cint): bool {.cdecl, importc: "wenclose", dynlib: libncurses.}
-proc mouseinterval*(a2: cint): cint {.cdecl, importc: "mouseinterval", dynlib: libncurses.}
-proc wmouse_trafo*(a2: ptr window; a3: ptr cint; a4: ptr cint; a5: bool): bool {.cdecl, importc: "wmouse_trafo", dynlib: libncurses.}
-proc mouse_trafo*(a2: ptr cint; a3: ptr cint; a4: bool): bool {.cdecl, importc: "mouse_trafo", dynlib: libncurses.}
+proc extended_color_content*() {.ncurses, importc: "".}
+proc extended_pair_content*() {.ncurses, importc: "".}
+proc extended_slk_color*() {.ncurses, importc: "".}
+proc filter*() {.ncurses, importc: "".}
+
+proc flushinp*() {.ncurses, importc: "".}
+
+proc get_wch*() {.ncurses, importc: "".}
+proc get_wstr*() {.ncurses, importc: "".}
+proc getattrs*(a2: ptr window): cint {.ncurses, importc: "getattrs".}
+proc getbegx*(a2: ptr window): cint {.ncurses, importc: "getbegx".}
+proc getbegy*(a2: ptr window): cint {.ncurses, importc: "getbegy".}
+proc getbegyx*() {.ncurses, importc: "".}
+proc getcurx*(a2: ptr window): cint {.ncurses, importc: "getcurx".}
+proc getcury*(a2: ptr window): cint {.ncurses, importc: "getcury".}
+proc getmaxx*(a2: ptr window): cint {.ncurses, importc: "getmaxx".}
+proc getmaxy*(a2: ptr window): cint {.ncurses, importc: "getmaxy".}
+proc getmaxyx*(win: ptr window, y, x: var int) =
+    ## retrieves the size of the specified window in the provided y and x parameters.
+    ## @Param: 'win' the window to measure.
+    ## @Param: 'y' stores the height of the window.
+    ## @Param: 'x' stores the width of the window.
+    y = getmaxy(win)
+    x = getmaxx(win)
+proc getparx*(a2: ptr window): cint {.ncurses, importc: "getparx".}
+proc getpary*(a2: ptr window): cint {.ncurses, importc: "getpary".}
+#proc *() {.ncurses, importc: "".}
+
+proc has_mouse*(): bool {.ncurses, importc: "has_mouse".}
+proc getmouse*(a2: ptr MEVENT): cint {.ncurses, importc: "getmouse".}
+proc ungetmouse*(a2: ptr MEVENT): cint {.ncurses, importc: "ungetmouse".}
+proc mousemask*(a2: mmask_t; a3: ptr mmask_t): mmask_t {.ncurses, importc: "mousemask".}
+proc wenclose*(a2: ptr window; a3: cint; a4: cint): bool {.ncurses, importc: "wenclose".}
+proc mouseinterval*(a2: cint): cint {.ncurses, importc: "mouseinterval".}
+proc wmouse_trafo*(a2: ptr window; a3: ptr cint; a4: ptr cint; a5: bool): bool {.ncurses, importc: "wmouse_trafo".}
+proc mouse_trafo*(a2: ptr cint; a3: ptr cint; a4: bool): bool {.ncurses, importc: "mouse_trafo".}
 
 # These functions are not in X/Open, but we use them in macro definitions:
 
 
 
-proc newwin*(lines, columns, begin_y, begin_x: int): ptr window {.cdecl, discardable, importc: "newwin", dynlib: libncurses.}
+proc newwin*(lines, columns, begin_y, begin_x: int): ptr window {.ncurses, importc: "newwin".}
 
-proc mvwin*(win: ptr window, y, x: int): cint {.cdecl, discardable, importc: "mvwin", dynlib: libncurses.}
+proc mvwin*(win: ptr window, y, x: int): cint {.ncurses, importc: "mvwin".}
 
-proc subpad*(orig: ptr window, lines, columns, begin_y, begin_x: int): ptr window {.cdecl, discardable, importc: "subpad", dynlib: libncurses.}
+proc subpad*(orig: ptr window, lines, columns, begin_y, begin_x: int): ptr window {.ncurses, importc: "subpad".}
 
-proc subwin*(orig: ptr window, lines, columns, begin_y, begin_x: int): ptr window {.cdecl, discardable, importc: "subwin", dynlib: libncurses.}
+proc subwin*(orig: ptr window, lines, columns, begin_y, begin_x: int): ptr window {.ncurses, importc: "subwin".}
 
-proc keypad*(win: ptr window, bf: bool): cint {.cdecl, discardable, importc: "keypad", dynlib: libncurses.}
+proc keypad*(win: ptr window, bf: bool): cint {.ncurses, importc: "keypad".}
 
-proc scrollok*(win: ptr window, bf: bool): cint {.cdecl, discardable, importc: "scrollok", dynlib: libncurses.}
+proc scrollok*(win: ptr window, bf: bool): cint {.ncurses, importc: "scrollok".}
 
-proc scroll*(win: ptr window): cint {.cdecl, discardable, importc: "scroll", dynlib: libncurses.}
+proc scroll*(win: ptr window): cint {.ncurses, importc: "scroll".}
 
-proc werase*(win: ptr window): cint {.cdecl, discardable, importc: "werase", dynlib: libncurses.}
+proc werase*(win: ptr window): cint {.ncurses, importc: "werase".}
 
-proc wclear*(win: ptr window): cint {.cdecl, discardable, importc: "wclear", dynlib: libncurses.}
+proc wclear*(win: ptr window): cint {.ncurses, importc: "wclear".}
 
-proc wrefresh*(win: ptr window): cint {.cdecl, discardable, importc: "wrefresh", dynlib: libncurses.}
+proc wrefresh*(win: ptr window): cint {.ncurses, importc: "wrefresh".}
 
-proc wattron*(win: ptr window, attributes: int64): cint {.cdecl, discardable, importc: "wattron", dynlib: libncurses.}
+proc wattron*(win: ptr window, attributes: int64): cint {.ncurses, importc: "wattron".}
 
-proc wattroff*(win: ptr window, attributes: int64): cint {.cdecl, discardable, importc: "wattroff", dynlib: libncurses.}
+proc wattroff*(win: ptr window, attributes: int64): cint {.ncurses, importc: "wattroff".}
 
-proc wresize*(win: ptr window, line, column: int): cint {.cdecl, discardable, importc: "wresize", dynlib: libncurses.}
+proc wresize*(win: ptr window, line, column: int): cint {.ncurses, importc: "wresize".}
 
-proc wmove*(win: ptr window, y, x: int): cint {.cdecl, discardable, importc: "wmove", dynlib: libncurses.}
+proc wmove*(win: ptr window, y, x: int): cint {.ncurses, importc: "wmove".}
 
-proc wbkgd*(win: ptr window, character: chtype): cint {.cdecl, discardable, importc: "wbkgd", dynlib: libncurses.}
+proc wprintw*(win: ptr window, formattedString: cstring): cint {.ncurses, importc: "wprintw".}
 
-proc wprintw*(win: ptr window, formattedString: cstring): cint {.cdecl, discardable, importc: "wprintw", dynlib: libncurses.}
+proc set_escdelay*(size: int): cint {.ncurses, importc: "set_escdelay".}
 
-proc mvwaddch*(win: ptr window, y, x: int, character: chtype): cint {.cdecl, discardable, importc: "mvwaddch", dynlib: libncurses.}
+proc reset_prog_mode*(): cint {.ncurses, importc: "reset_prog_mode".}
 
-proc mvwaddstr*(win: ptr window, y, x: int, str: cstring): cint {.cdecl, discardable, importc: "mvwaddstr", dynlib: libncurses.}
+proc raw*(): cint {.ncurses, importc: "raw".}
 
-proc set_escdelay*(size: int): cint {.cdecl, discardable, importc: "set_escdelay", dynlib: libncurses.}
+proc timeout*(delay: cint) {.ncurses, importc: "timeout".}
 
-proc reset_prog_mode*(): cint {.cdecl, discardable, importc: "reset_prog_mode", dynlib: libncurses.}
+proc nodelay*(win: ptr window, bf: bool): cint {.ncurses, importc: "nodelay".}
 
-proc raw*(): cint {.cdecl, discardable, importc: "raw", dynlib: libncurses.}
-
-proc timeout*(delay: cint) {.cdecl, discardable, importc: "timeout", dynlib: libncurses.}
-
-proc nodelay*(win: ptr window, bf: bool): cint {.cdecl, discardable, importc: "nodelay", dynlib: libncurses.}
-
-proc noecho*(): cint {.cdecl, discardable, importc: "noecho", dynlib: libncurses.}
-
-proc onecho*(): cint {.cdecl, discardable, importc: "echo", dynlib: libncurses.}
-
-proc use_default_colors*(): cint {.cdecl, discardable, importc: "use_default_colors", dynlib: libncurses.}
-
-proc flash*(): cint {.cdecl, discardable, importc: "flash", dynlib: libncurses.}
-    ## Flashes the screen and if that is not possible it sounds the alert. If this is not possible
-    ## nothing happens.
-    ## @Returns: ERR on failure and OK upon successfully flashing.
-
-proc getch*(): cint {.cdecl, discardable, importc: "getch", dynlib: libncurses.}
+proc getch*(): cint {.ncurses, importc: "getch".}
     ## Read a character from the stdscr window.
     ## @Returns: ERR on failure and OK upon successful completion.
 
-proc getnstr*(inputString: cstring; numberOfCharacters: int): cint {.cdecl, discardable, importc: "getnstr", dynlib: libncurses.}
+proc getnstr*(inputString: cstring; numberOfCharacters: int): cint {.ncurses, importc: "getnstr".}
     ## Reads at most the specified number of characters into the provided string.
     ## @Param: 'inputString' the variable to read the input into.
     ## @Param: 'numberOfCharacters' the maximum number of characters to read.
     ## @Returns: ERR on failure and OK upon successful completion.
 
-proc getstr*(inputString: cstring): cint {.cdecl, discardable, importc: "getstr", dynlib: libncurses.}
+proc getstr*(inputString: cstring): cint {.ncurses, importc: "getstr".}
     ## Reads the inputted characters into the provided string.
     ## @Param: 'inputString' the variable to read the input into.
     ## @Returns: ERR on failure and OK upon successful completion.
 
-proc has_colors*(): bool {.cdecl, importc: "has_colors", dynlib: libncurses.}
+proc has_colors*(): bool {.ncurses, importc: "has_colors".}
     ## Used to determine if the terminal can manipulate colours.
     ## @Returns: true if the terminal can manipulate colours or false if it cannot.
 
-proc init_color*(color: cshort, r: cshort, g: cshort, b: cshort): cint {.cdecl, discardable, importc: "init_color", dynlib: libncurses.}
+proc init_color*(color: cshort, r: cshort, g: cshort, b: cshort): cint {.ncurses, importc: "init_color".}
 
-proc init_pair*(pair: cshort; foreground: cshort; background: cshort): cint {.cdecl, discardable, importc: "init_pair", dynlib: libncurses.}
+proc init_pair*(pair: cshort; foreground: cshort; background: cshort): cint {.ncurses, importc: "init_pair".}
     ## Changes the definition of a colour pair.
     ## @Param: 'pair' the number of the colour pair to change.
     ## @Param: 'foreground': the foreground colour number.
     ## @Param: 'background': the background colour number.
     ## @Returns: ERR on failure and OK upon successful completion.
 
-proc initscr*(): ptr window {.cdecl, discardable, importc: "initscr", dynlib: libncurses.}
+proc initscr*(): ptr window {.ncurses, importc: "initscr".}
     ## Usually the first curses routine to be called when initialising a program
     ## The initscr code determines the terminal type and initialises  all curses data structures.  initscr also causes the
     ## first call to refresh to clear the screen.
@@ -449,22 +521,22 @@ proc initscr*(): ptr window {.cdecl, discardable, importc: "initscr", dynlib: li
     ## @Note: If errors occur, initscr writes an appropriate error message to
     ## standard error and exits.
 
-proc insch*(character: chtype): cint {.cdecl, discardable, importc: "insch", dynlib: libncurses.}
+proc insch*(character: chtype): cint {.ncurses, importc: "insch".}
     ## Inserts a character before the cursor in the stdscr.
     ## @Param: 'character' the character to insert.
     ## @Returns: ERR on failure and OK upon successful completion.
 
-proc insertln*(): cint {.cdecl, discardable, importc: "insertln", dynlib: libncurses.}
+proc insertln*(): cint {.ncurses, importc: "insertln".}
     ## Inserts a blank line above the current line in stdscr and the bottom line is lost.
     ## @Returns: ERR on failure and OK upon successful completion.
 
-proc move*(y: int; x: int): cint {.cdecl, discardable, importc: "move", dynlib: libncurses.}
+proc move*(y: int; x: int): cint {.ncurses, importc: "move".}
     ## Moves the cursor of stdscr to the specified coordinates.
     ## @Param: 'y' the line to move the cursor to.
     ## @Param: 'x' the column to move the cursor to.
     ## @Returns: ERR on failure and OK upon successful completion.
 
-proc mvaddch*(y: int; x: int; character: chtype): cint {.cdecl, discardable, importc: "mvaddch", dynlib: libncurses.}
+proc mvaddch*(y: int; x: int; character: chtype): cint {.ncurses, importc: "mvaddch".}
     ## Moves the cursor to the specified position and outputs the provided character.
     ## The cursor is then advanced to the next position.
     ## @Param: 'y' the line to move the cursor to.
@@ -472,22 +544,14 @@ proc mvaddch*(y: int; x: int; character: chtype): cint {.cdecl, discardable, imp
     ## @Param: 'character' the character to put into the current window.
     ## @Returns: ERR on failure and OK upon successful completion.
 
-proc mvaddstr*(y: int; x: int; stringToOutput: cstring): cint {.cdecl, discardable, importc: "mvaddstr", dynlib: libncurses.}
-    ## Moves the cursor to the specified position and outputs the provided string.
-    ## The cursor is then advanced to the next position.
-    ## @Param: 'y' the line to move the cursor to.
-    ## @Param: 'x' the column to move the cursor to.
-    ## @Param: 'stringToOutput' the string to put into the current window.
-    ## @Returns: ERR on failure and OK upon successful completion.
-
-proc mvprintw*(y: int; x: int; formattedString: cstring): cint {.varargs, cdecl, discardable, importc: "mvprintw", dynlib: libncurses.}
+proc mvprintw*(y: int; x: int; formattedString: cstring): cint {.varargs, ncurses, importc: "mvprintw".}
     ## Prints out a formatted string to the stdscr at the specified row and column.
     ## @Param: 'y' the line to move the cursor to.
     ## @Param: 'x' the column to move the cursor to.
     ## @Param: 'formattedString' the string with formatting to be output to stdscr.
     ## @Returns: ERR on failure and OK upon successful completion.
 
-proc mvwprintw*(destinationWindow: ptr window; y: int; x: int; formattedString: cstring): cint {.varargs, cdecl, discardable, importc: "mvwprintw", dynlib: libncurses.}
+proc mvwprintw*(destinationWindow: ptr window; y: int; x: int; formattedString: cstring): cint {.varargs, ncurses, importc: "mvwprintw".}
     ## Prints out a formatted string to the specified window at the specified row and column.
     ## @Param: 'destinationWindow' the window to write the string to.
     ## @Param: 'y' the line to move the cursor to.
@@ -495,43 +559,33 @@ proc mvwprintw*(destinationWindow: ptr window; y: int; x: int; formattedString: 
     ## @Param: 'formattedString' the string with formatting to be output to stdscr.
     ## @Returns: ERR on failure and OK upon successful completion.
 
-proc napms*(milliseconds: int): cint {.cdecl, discardable, importc: "napms", dynlib: libncurses.}
+proc napms*(milliseconds: int): cint {.ncurses, importc: "napms".}
     ## Used to sleep for the specified milliseconds.
     ## @Params: 'milliseconds' the number of milliseconds to sleep for.
     ## @Returns: ERR on failure and OK upon successful completion.
 
-proc nocbreak*(): cint {.cdecl, discardable, importc: "nocbreak", dynlib: libncurses.}
-    ## Returns the terminal to normal (cooked mode).
-    ## @Returns: ERR on failure and OK upon successful completion.
-
-proc printw*(formattedString: cstring): cint {.varargs, cdecl, discardable, importc: "printw", dynlib: libncurses.}
+proc printw*(formattedString: cstring): cint {.varargs, ncurses, importc: "printw".}
     ## Prints out a formatted string to the stdscr.
     ## @Param: 'formattedString' the string with formatting to be output to stdscr.
     ## @Returns: ERR on failure and OK upon successful completion.
 
-proc refresh*(): cint {.cdecl, discardable, importc: "refresh", dynlib: libncurses.}
+proc refresh*(): cint {.ncurses, importc: "refresh".}
     ## Must be called to get actual output to the terminal. refresh uses stdscr has the default window.
     ## @Returns: ERR on failure and OK upon successful completion.
 
-proc scanw*(formattedInput: cstring): int {.varargs, cdecl, discardable, importc: "scanw", dynlib: libncurses.}
+proc scanw*(formattedInput: cstring): int {.varargs, ncurses, importc: "scanw".}
     ## Converts formatted input from the stdscr.
     ## @Param: 'formattedInput' Contains the fields for the input to be mapped to.
     ## @Returns: The number of fields that were mapped in the call.
 
-proc start_color*(): cint {.cdecl, discardable, importc: "start_color", dynlib: libncurses.}
+proc start_color*(): cint {.ncurses, importc: "start_color".}
     ## Initialises the the eight basic colours and the two global varables COLORS and COLOR_PAIRS.
     ## It also restores the colours on the terminal to the values that they had when the
     ## terminal was just turned on.
     ## @Note: It is good practice to call this routine right after initscr. It must be
     ## called before any other colour manipulating routines.
 
-proc waddstr*(destinationWindow: ptr window; stringToWrite: cstring): cint {.cdecl, discardable, importc: "waddstr", dynlib: libncurses.}
-    ## Writes a string to the specified window.
-    ## @Param: 'destinationWindow' the window to write the string to.
-    ## @Param: 'stringToWrite'
-    ## @Returns: ERR on failure and OK upon successful completion.
-
-proc wgetch*(sourceWindow: ptr window): cint {.cdecl, discardable, importc: "wgetch", dynlib: libncurses.}
+proc wgetch*(sourceWindow: ptr window): cint {.ncurses, importc: "wgetch".}
     ## Read a character from the specified window.
     ## @Param: 'sourceWindow' the window to read a character from.
     ## @Returns: ERR on failure and OK upon successful completion.
@@ -543,3 +597,165 @@ proc getyx*(win: ptr window, y, x: var int) =
     ## @Param: 'x' stores the width of the window.
     y = getcury(win)
     x = getcurx(win)
+
+# mouse interface
+template NCURSES_MOUSE_MASK(b, m: untyped): untyped = ((m) shl (((b) - 1) * 5))
+template BUTTON_RELEASE*(e, x: untyped): untyped =
+ ((e) and NCURSES_MOUSE_MASK(x, NCURSES_BUTTON_RELEASED))
+template BUTTON_PRESS*(e, x: untyped): untyped =
+ ((e) and NCURSES_MOUSE_MASK(x, NCURSES_BUTTON_PRESSED))
+template BUTTON_CLICK*(e, x: untyped): untyped =
+ ((e) and NCURSES_MOUSE_MASK(x, NCURSES_BUTTON_CLICKED))
+template BUTTON_DOUBLE_CLICK*(e, x: untyped): untyped =
+ ((e) and NCURSES_MOUSE_MASK(x, NCURSES_DOUBLE_CLICKED))
+template BUTTON_TRIPLE_CLICK*(e, x: untyped): untyped =
+ ((e) and NCURSES_MOUSE_MASK(x, NCURSES_TRIPLE_CLICKED))
+template BUTTON_RESERVED_EVENT*(e, x: untyped): untyped =
+ ((e) and NCURSES_MOUSE_MASK(x, NCURSES_RESERVED_EVENT))
+
+const
+  NCURSES_BUTTON_RELEASED* = 0o01'i32
+  NCURSES_BUTTON_PRESSED*  = 0o02'i32
+  NCURSES_BUTTON_CLICKED*  = 0o04'i32
+  NCURSES_DOUBLE_CLICKED*  = 0o10'i32
+  NCURSES_TRIPLE_CLICKED*  = 0o20'i32
+  NCURSES_RESERVED_EVENT*  = 0o40'i32
+
+  # event masks
+  BUTTON1_RELEASED* = NCURSES_MOUSE_MASK(1, NCURSES_BUTTON_RELEASED)
+  BUTTON1_PRESSED*  = NCURSES_MOUSE_MASK(1, NCURSES_BUTTON_PRESSED)
+  BUTTON1_CLICKED*  = NCURSES_MOUSE_MASK(1, NCURSES_BUTTON_CLICKED)
+  BUTTON1_DOUBLE_CLICKED* = NCURSES_MOUSE_MASK(1, NCURSES_DOUBLE_CLICKED)
+  BUTTON1_TRIPLE_CLICKED* = NCURSES_MOUSE_MASK(1, NCURSES_TRIPLE_CLICKED)
+  BUTTON2_RELEASED* = NCURSES_MOUSE_MASK(2, NCURSES_BUTTON_RELEASED)
+  BUTTON2_PRESSED*  = NCURSES_MOUSE_MASK(2, NCURSES_BUTTON_PRESSED)
+  BUTTON2_CLICKED*  = NCURSES_MOUSE_MASK(2, NCURSES_BUTTON_CLICKED)
+  BUTTON2_DOUBLE_CLICKED* = NCURSES_MOUSE_MASK(2, NCURSES_DOUBLE_CLICKED)
+  BUTTON2_TRIPLE_CLICKED* = NCURSES_MOUSE_MASK(2, NCURSES_TRIPLE_CLICKED)
+  BUTTON3_RELEASED* = NCURSES_MOUSE_MASK(3, NCURSES_BUTTON_RELEASED)
+  BUTTON3_PRESSED*  = NCURSES_MOUSE_MASK(3, NCURSES_BUTTON_PRESSED)
+  BUTTON3_CLICKED*  = NCURSES_MOUSE_MASK(3, NCURSES_BUTTON_CLICKED)
+  BUTTON3_DOUBLE_CLICKED* = NCURSES_MOUSE_MASK(3, NCURSES_DOUBLE_CLICKED)
+  BUTTON3_TRIPLE_CLICKED* = NCURSES_MOUSE_MASK(3, NCURSES_TRIPLE_CLICKED)
+  BUTTON4_RELEASED* = NCURSES_MOUSE_MASK(4, NCURSES_BUTTON_RELEASED)
+  BUTTON4_PRESSED*  = NCURSES_MOUSE_MASK(4, NCURSES_BUTTON_PRESSED)
+  BUTTON4_CLICKED*  = NCURSES_MOUSE_MASK(4, NCURSES_BUTTON_CLICKED)
+  BUTTON4_DOUBLE_CLICKED* = NCURSES_MOUSE_MASK(4, NCURSES_DOUBLE_CLICKED)
+  BUTTON4_TRIPLE_CLICKED* = NCURSES_MOUSE_MASK(4, NCURSES_TRIPLE_CLICKED)
+  BUTTON5_RELEASED* = NCURSES_MOUSE_MASK(5, NCURSES_BUTTON_RELEASED)
+  BUTTON5_PRESSED*  = NCURSES_MOUSE_MASK(5, NCURSES_BUTTON_PRESSED)
+  BUTTON5_CLICKED*  = NCURSES_MOUSE_MASK(5, NCURSES_BUTTON_CLICKED)
+  BUTTON5_DOUBLE_CLICKED* = NCURSES_MOUSE_MASK(5, NCURSES_DOUBLE_CLICKED)
+  BUTTON5_TRIPLE_CLICKED* = NCURSES_MOUSE_MASK(5, NCURSES_TRIPLE_CLICKED)
+  BUTTON_CTRL*  = NCURSES_MOUSE_MASK(6, 1)
+  BUTTON_SHIFT* = NCURSES_MOUSE_MASK(6, 2)
+  BUTTON_ALT*   = NCURSES_MOUSE_MASK(6, 4)
+  
+  # keys
+  KEY_CODE_YES*  = 0o400           # A wchar_t contains a key code
+  KEY_MIN*       = 0o401           # Minimum curses key
+  KEY_BREAK*     = 0o401           # Break key (unreliable)
+  KEY_SRESET*    = 0o530           # Soft (partial) reset (unreliable)
+  KEY_RESET*     = 0o531           # Reset or hard reset (unreliable)
+
+  KEY_DOWN*      = 0o402           # down-arrow key
+  KEY_UP*        = 0o403           # up-arrow key
+  KEY_LEFT*      = 0o404           # left-arrow key
+  KEY_RIGHT*     = 0o405           # right-arrow key
+  KEY_HOME*      = 0o406           # home key
+  KEY_BACKSPACE* = 0o407           # backspace key
+  KEY_F0*        = 0o410           # Function keys.  Space for 64
+  KEY_DL*        = 0o510           # delete-line key
+  KEY_IL*        = 0o511           # insert-line key
+  KEY_DC*        = 0o512           # delete-character key
+  KEY_IC*        = 0o513           # insert-character key
+  KEY_EIC*       = 0o514           # sent by rmir or smir in insert mode
+  KEY_CLEAR*     = 0o515           # clear-screen or erase key
+  KEY_EOS*       = 0o516           # clear-to-end-of-screen key
+  KEY_EOL*       = 0o517           # clear-to-end-of-line key
+  KEY_SF*        = 0o520           # scroll-forward key
+  KEY_SR*        = 0o521           # scroll-backward key
+  KEY_NPAGE*     = 0o522           # next-page key
+  KEY_PPAGE*     = 0o523           # previous-page key
+  KEY_STAB*      = 0o524           # set-tab key
+  KEY_CTAB*      = 0o525           # clear-tab key
+  KEY_CATAB*     = 0o526           # clear-all-tabs key
+  KEY_ENTER*     = 0o527           # enter/send key
+  KEY_PRINT*     = 0o532           # print key
+  KEY_LL*        = 0o533           # lower-left key (home down)
+  KEY_A1*        = 0o534           # upper left of keypad
+  KEY_A3*        = 0o535           # upper right of keypad
+  KEY_B2*        = 0o536           # center of keypad
+  KEY_C1*        = 0o537           # lower left of keypad
+  KEY_C3*        = 0o540           # lower right of keypad
+  KEY_BTAB*      = 0o541           # back-tab key
+  KEY_BEG*       = 0o542           # begin key
+  KEY_CANCEL*    = 0o543           # cancel key
+  KEY_CLOSE*     = 0o544           # close key
+  KEY_COMMAND*   = 0o545           # command key
+  KEY_COPY*      = 0o546           # copy key
+  KEY_CREATE*    = 0o547           # create key
+  KEY_END*       = 0o550           # end key
+  KEY_EXIT*      = 0o551           # exit key
+  KEY_FIND*      = 0o552           # find key
+  KEY_HELP*      = 0o553           # help key
+  KEY_MARK*      = 0o554           # mark key
+  KEY_MESSAGE*   = 0o555           # message key
+  KEY_MOVE*      = 0o556           # move key
+  KEY_NEXT*      = 0o557           # next key
+  KEY_OPEN*      = 0o560           # open key
+  KEY_OPTIONS*   = 0o561           # options key
+  KEY_PREVIOUS*  = 0o562           # previous key
+  KEY_REDO*      = 0o563           # redo key
+  KEY_REFERENCE* = 0o564           # reference key
+  KEY_REFRESH*   = 0o565           # refresh key
+  KEY_REPLACE*   = 0o566           # replace key
+  KEY_RESTART*   = 0o567           # restart key
+  KEY_RESUME*    = 0o570           # resume key
+  KEY_SAVE*      = 0o571           # save key
+  KEY_SBEG*      = 0o572           # shifted begin key
+  KEY_SCANCEL*   = 0o573           # shifted cancel key
+  KEY_SCOMMAND*  = 0o574           # shifted command key
+  KEY_SCOPY*     = 0o575           # shifted copy key
+  KEY_SCREATE*   = 0o576           # shifted create key
+  KEY_SDC*       = 0o577           # shifted delete-character key
+  KEY_SDL*       = 0o600           # shifted delete-line key
+  KEY_SELECT*    = 0o601           # select key
+  KEY_SEND*      = 0o602           # shifted end key
+  KEY_SEOL*      = 0o603           # shifted clear-to-end-of-line key
+  KEY_SEXIT*     = 0o604           # shifted exit key
+  KEY_SFIND*     = 0o605           # shifted find key
+  KEY_SHELP*     = 0o606           # shifted help key
+  KEY_SHOME*     = 0o607           # shifted home key
+  KEY_SIC*       = 0o610           # shifted insert-character key
+  KEY_SLEFT*     = 0o611           # shifted left-arrow key
+  KEY_SMESSAGE*  = 0o612           # shifted message key
+  KEY_SMOVE*     = 0o613           # shifted move key
+  KEY_SNEXT*     = 0o614           # shifted next key
+  KEY_SOPTIONS*  = 0o615           # shifted options key
+  KEY_SPREVIOUS* = 0o616           # shifted previous key
+  KEY_SPRINT*    = 0o617           # shifted print key
+  KEY_SREDO*     = 0o620           # shifted redo key
+  KEY_SREPLACE*  = 0o621           # shifted replace key
+  KEY_SRIGHT*    = 0o622           # shifted right-arrow key
+  KEY_SRSUME*    = 0o623           # shifted resume key
+  KEY_SSAVE*     = 0o624           # shifted save key
+  KEY_SSUSPEND*  = 0o625           # shifted suspend key
+  KEY_SUNDO*     = 0o626           # shifted undo key
+  KEY_SUSPEND*   = 0o627           # suspend key
+  KEY_UNDO*      = 0o630           # undo key
+  KEY_MOUSE*     = 0o631           # Mouse event has occurred
+  KEY_RESIZE*    = 0o632           # Terminal resize event
+  KEY_EVENT*     = 0o633           # We were interrupted by an event
+
+  # colors
+  COLOR_BLACK*   = 0
+  COLOR_RED*     = 1
+  COLOR_GREEN*   = 2
+  COLOR_YELLOW*  = 3
+  COLOR_BLUE*    = 4
+  COLOR_MAGENTA* = 5
+  COLOR_CYAN*    = 6
+  COLOR_WHITE*   = 7
+
+template KEY_F*(n: untyped): untyped= (KEY_F0+(n))    # Value of function key n

--- a/ncurses.nimble
+++ b/ncurses.nimble
@@ -1,6 +1,6 @@
 [Package]
 name          = "ncurses"
-version       = "0.1.0"
+version       = "1.0.0"
 author        = "Raymond Nowley"
 description   = "A wrapper for NCurses"
 license       = "MIT"

--- a/ncurses.nimble
+++ b/ncurses.nimble
@@ -1,9 +1,9 @@
-[Package]
+# Package
 name          = "ncurses"
 version       = "1.0.0"
 author        = "Raymond Nowley"
 description   = "A wrapper for NCurses"
 license       = "MIT"
 
-[Deps]
-Requires: "nim >= 0.10.0"
+# Dependencies
+requires "nim >= 0.10.0"


### PR DESCRIPTION
Hi, this is my first pull request so please let me know if I'm doing something wrong. I added the rest of the ncurses library (as far as i know, might have missed some things, but i don't think so). I preserved all comments which were present from before, and added some new ones to certain functions.

Naming changes from original ncurses source (because of nim style insensitivity):
- `slk_attron, slk_attroff, slk_attrset`, they include _ch at the end (`slk_attron_ch`)
- `resizeterm` is now `resize_term_ext`
- `termattrs` is now `term_attrs_ch`
- `vidputs, vidattr` include _ch at the end (`vid_puts_ch`)
- `key_name` is `keyname_wch`

Differences from previous versions, other than added functions:
- functions which return exclusively `ERR` or `OK` now return `ErrCode`, which is just a typedef to cint
- `window` is now `Window` (window is still included, but deprecated), other types added also include `Terminal` and `Screen`
- `PWindow, PScreen, PTerminal` added as pointer versions of their type
- `PWindow` is now used instead of `ptr window`
- `cchar_t` is added (construct with `setcchar()`)
- functions are grouped together logically and each group has a header and a brief description
- rest of the key_codes added
- made the const declarations more true to the original source

btw old code using this library should still work with this version :-)